### PR TITLE
refactor!: simplify manager and cleanup hook and manager

### DIFF
--- a/classes/hook/gather_metrics.php
+++ b/classes/hook/gather_metrics.php
@@ -29,35 +29,46 @@
 
 namespace tool_monitoring\hook;
 
+use core\attribute\label;
+use core\attribute\tags;
 use tool_monitoring\metric;
 
 /**
- * Hook dispatched at the very call on the metrics api.
+ * Linchpin of the monitoring API.
+ *
+ * Hook callbacks can register metrics via the {@see add_metric} method.
+ * Registered metrics can be retrieved with the {@see get_metrics} method.
+ *
+ * @package    tool_monitoring
+ * @copyright  2025 MootDACH DevCamp
+ *             Daniel Fainberg <d.fainberg@tu-berlin.de>
+ *             Martin Gauk <martin.gauk@tu-berlin.de>
+ *             Sebastian Rupp <sr@artcodix.com>
+ *             Malte Schmitz <mal.schmitz@uni-luebeck.de>
+ *             Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-#[\core\attribute\label('Hook dispatched at the very call on the metrics api.')]
-#[\core\attribute\tags('metric')]
+#[label('Provides the ability to register custom metrics.')]
+#[tags('metric', 'monitoring', 'tool_monitoring')]
 final class gather_metrics {
 
-    /**
-     * List of registered metrics.
-     *
-     * @var metric[]
-     */
+    /** @var metric[] All registered metrics indexed by name. */
     private array $metrics = [];
 
     /**
-     * Registers a metric.
+     * Registers the provided metric.
      *
      * @param metric $metric
      */
-    public function add_metric(metric $metric) {
-        $this->metrics[] = $metric;
+    public function add_metric(metric $metric): void {
+        // TODO: Ensure unique names?
+        $this->metrics[$metric::get_name()] = $metric;
     }
 
     /**
-     * Get all registered metrics class names.
+     * Returns all registered metrics.
      *
-     * @return metric[]
+     * @return metric[] Metrics indexed by name.
      */
     public function get_metrics(): array {
         return $this->metrics;

--- a/classes/metrics_manager.php
+++ b/classes/metrics_manager.php
@@ -29,50 +29,52 @@
 
 namespace tool_monitoring;
 
+use core\di;
+use core\hook\manager;
+use tool_monitoring\hook\gather_metrics;
+
 /**
  * Metrics manager to gather all available metrics and operations.
+ *
+ * @package    tool_monitoring
+ * @copyright  2025 MootDACH DevCamp
+ *             Daniel Fainberg <d.fainberg@tu-berlin.de>
+ *             Martin Gauk <martin.gauk@tu-berlin.de>
+ *             Sebastian Rupp <sr@artcodix.com>
+ *             Malte Schmitz <mal.schmitz@uni-luebeck.de>
+ *             Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class metrics_manager {
-    /**
-     * All available metrics in the system.
-     *
-     * @var metric[]
-     */
+final class metrics_manager {
+
+    /** @var metric[] All available metrics in the system indexed by name. */
     protected array $metrics = [];
 
     /**
-     * Constructor that gathers all available metrics.
+     * Dispatches the {@see gather_metrics} hook and then stores all available metrics.
      */
     public function __construct() {
-        $hook = new \tool_monitoring\hook\gather_metrics();
-        \core\di::get(\core\hook\manager::class)->dispatch($hook);
-
+        $hook = new gather_metrics();
+        di::get(manager::class)->dispatch($hook);
         $this->metrics = $hook->get_metrics();
     }
 
     /**
-     * Get all available metrics.
+     * Returns the registered metrics.
      *
-     * @return metric[]
-     */
-    public function get_all_metrics(): array {
-        return $this->metrics;
-    }
-
-    /**
-     * Filter the metrics by tag and return the metric names with their values.
+     * Optionally filters the metrics by tag.
      *
-     * @param string $tag
-     * @return metric[]
+     * @param string|null $tag If provided, only metrics with that tag will be returned.
+     * @return metric[] Metrics indexed by their name.
      */
-    public function get_needed_metrics(string $tag): array {
-        // TODO: filter.
-        $metrics = [];
-
-        foreach ($this->metrics as $metric) {
-            $metrics[$metric::get_name()] = $metric;
+    public function get_metrics(string|null $tag = null): array {
+        if (is_null($tag)) {
+            return $this->metrics;
         }
-
-        return $metrics;
+        // TODO: Implement configurable tags for metrics via settings and filter the metrics accordingly here.
+        return array_filter(
+            $this->metrics,
+            fn (metric $metric): bool => true,
+        );
     }
 }

--- a/classes/output/overview.php
+++ b/classes/output/overview.php
@@ -39,7 +39,7 @@ class overview implements renderable, templatable {
      */
     public function export_for_template(\core\output\renderer_base $output) {
         $manager = new metrics_manager();
-        $metrics = $manager->get_all_metrics();
+        $metrics = $manager->get_metrics();
         $lines = [];
         foreach ($metrics as $metric) {
             $lines[] = [

--- a/exporter/prometheus/classes/route/controller/prometheus.php
+++ b/exporter/prometheus/classes/route/controller/prometheus.php
@@ -45,7 +45,7 @@ class prometheus {
         $response = $response->withHeader('Content-Type', 'text/plain; charset=utf-8');
         $manager = new metrics_manager();
         $response->getBody()->write(
-            monitoringexporter_prometheus\exporter::export($manager->get_needed_metrics($tag))
+            monitoringexporter_prometheus\exporter::export($manager->get_metrics($tag))
         );
 
         return $response;


### PR DESCRIPTION
- The `get_needed_metrics` method of the `metrics_manager` is now just `get_metrics` and accepts an optional `tag` argument, making the `get_all_metrics` method obsolete.
- The `gather_metrics` hook now indexes its `metrics` array by the metric name.
- The hook also has a more descriptive label and additional tags.
- PHPDoc blocks in both classes are now standardized and extensive.
- Qualifiers are replaced with imports.
- TODOs expanded.