### PR TITLE
Standardize language strings, rebase (close #29)

### DIFF
--- a/classes/event/metric_config_updated.php
+++ b/classes/event/metric_config_updated.php
@@ -51,7 +51,7 @@ class metric_config_updated extends metric_event {
      */
     #[\Override]
     public static function get_name(): lang_string {
-        return new lang_string('metricconfigupdated', 'tool_monitoring');
+        return new lang_string('event:metric_config_updated', 'tool_monitoring');
     }
 
     /**

--- a/classes/form/config.php
+++ b/classes/form/config.php
@@ -63,27 +63,27 @@ class config extends moodleform {
         $this->_form->setType('metric', PARAM_ALPHAEXT);
         $this->add_static_field(
             name: 'component',
-            label: new lang_string('component', 'tool_monitoring'),
+            label: new lang_string('settings:component', 'tool_monitoring'),
             value: $this->metric->component,
         );
         $this->add_static_field(
             name: 'name',
-            label: new lang_string('name', 'tool_monitoring'),
+            label: new lang_string('settings:name', 'tool_monitoring'),
             value: $this->metric->name,
         );
         $this->add_static_field(
             name: 'type',
-            label: new lang_string('type', 'tool_monitoring'),
+            label: new lang_string('settings:type', 'tool_monitoring'),
             value: $this->metric->type->value,
         );
         $this->add_static_field(
             name: 'description',
-            label: new lang_string('description', 'tool_monitoring'),
+            label: new lang_string('settings:description', 'tool_monitoring'),
             value: $this->metric->description,
         );
         $this->add_advanced_checkbox_field(
             name: 'enabled',
-            label: new lang_string('metricenabled', 'tool_monitoring'),
+            label: new lang_string('settings:metric_enabled', 'tool_monitoring'),
         );
         $this->add_tags_field(
             itemtype: 'metrics',

--- a/classes/local/metrics/courses.php
+++ b/classes/local/metrics/courses.php
@@ -59,7 +59,7 @@ class courses extends metric {
      * {@inheritDoc}
      */
     public static function get_description(): lang_string {
-        return new lang_string('courses_description', 'tool_monitoring');
+        return new lang_string('metric:courses_description', 'tool_monitoring');
     }
 
     /**

--- a/classes/local/metrics/overdue_tasks.php
+++ b/classes/local/metrics/overdue_tasks.php
@@ -59,7 +59,7 @@ class overdue_tasks extends metric {
      * {@inheritDoc}
      */
     public static function get_description(): lang_string {
-        return new lang_string('overdue_tasks_description', 'tool_monitoring');
+        return new lang_string('metric:overdue_tasks_description', 'tool_monitoring');
     }
 
     /**

--- a/classes/local/metrics/quiz_attempts_in_progress.php
+++ b/classes/local/metrics/quiz_attempts_in_progress.php
@@ -63,7 +63,7 @@ class quiz_attempts_in_progress extends metric_with_config {
      * {@inheritDoc}
      */
     public static function get_description(): lang_string {
-        return new lang_string('quiz_attempts_in_progress_description', 'tool_monitoring');
+        return new lang_string('metric:quiz_attempts_in_progress_description', 'tool_monitoring');
     }
 
     /**

--- a/classes/local/metrics/user_accounts.php
+++ b/classes/local/metrics/user_accounts.php
@@ -60,7 +60,7 @@ class user_accounts extends metric {
      * {@inheritDoc}
      */
     public static function get_description(): lang_string {
-        return new lang_string('user_accounts_description', 'tool_monitoring');
+        return new lang_string('metric:user_accounts_description', 'tool_monitoring');
     }
 
     /**

--- a/classes/local/metrics/users_online.php
+++ b/classes/local/metrics/users_online.php
@@ -60,7 +60,7 @@ class users_online extends metric_with_config {
      * {@inheritDoc}
      */
     public static function get_description(): lang_string {
-        return new lang_string('users_online_description', 'tool_monitoring');
+        return new lang_string('metric:users_online_description', 'tool_monitoring');
     }
 
     /**

--- a/classes/local/metrics/users_online_config.php
+++ b/classes/local/metrics/users_online_config.php
@@ -137,9 +137,9 @@ final readonly class users_online_config implements metric_config {
 
     #[\Override]
     public static function extend_form_definition(config_form $configform, MoodleQuickForm $mform): void {
-        $mform->addElement('text', 'timewindows', new lang_string('users_online_time_windows', 'tool_monitoring'));
+        $mform->addElement('text', 'timewindows', new lang_string('metric:users_online_config:timewindows', 'tool_monitoring'));
         $mform->setType('timewindows', PARAM_TEXT);
-        $mform->addHelpButton('timewindows', 'users_online_time_windows', 'tool_monitoring');
+        $mform->addHelpButton('timewindows', 'metric:users_online_config:timewindows', 'tool_monitoring');
         $mform->addRule('timewindows', null, 'required', null, 'client');
     }
 

--- a/configure.php
+++ b/configure.php
@@ -45,8 +45,8 @@ require_capability('tool/monitoring:manage_metrics', $context);
 $qualifiedname = required_param('metric', PARAM_ALPHAEXT);
 $PAGE->set_url('/admin/tool/monitoring/configure.php', ['metric' => $qualifiedname]);
 $PAGE->set_context($context);
-$PAGE->set_title(get_string('monitoring_metrics', 'tool_monitoring'));
-$PAGE->set_heading(get_string('monitoring_metrics', 'tool_monitoring'));
+$PAGE->set_title(get_string('settings:monitoring_metrics', 'tool_monitoring'));
+$PAGE->set_heading(get_string('settings:monitoring_metrics', 'tool_monitoring'));
 $PAGE->add_body_class('limitedwidth');
 
 $manager = new metrics_manager();

--- a/exporter/prometheus/lang/en/monitoringexporter_prometheus.php
+++ b/exporter/prometheus/lang/en/monitoringexporter_prometheus.php
@@ -28,5 +28,5 @@
  */
 
 $string['pluginname'] = 'Exporter Prometheus';
-$string['setting_token'] = 'Token';
-$string['setting_token_desc'] = 'The token which has to be passed when the endpoint is called.';
+$string['settings:token'] = 'Token';
+$string['settings:token_desc'] = 'The token which has to be passed when the endpoint is called.';

--- a/exporter/prometheus/settings.php
+++ b/exporter/prometheus/settings.php
@@ -33,8 +33,8 @@ if ($hassiteconfig) {
     $settings->add(
         new admin_setting_configpasswordunmask(
             name: 'monitoringexporter_prometheus/prometheus_token',
-            visiblename: get_string('setting_token', 'monitoringexporter_prometheus'),
-            description: get_string('setting_token_desc', 'monitoringexporter_prometheus'),
+            visiblename: get_string('settings:token', 'monitoringexporter_prometheus'),
+            description: get_string('settings:token_desc', 'monitoringexporter_prometheus'),
             defaultsetting: '',
         )
     );

--- a/index.php
+++ b/index.php
@@ -56,8 +56,8 @@ if ($taglist) {
 
 $PAGE->set_url('/admin/tool/monitoring/', $params);
 $PAGE->set_context($context);
-$PAGE->set_title(get_string('monitoring_metrics', 'tool_monitoring'));
-$PAGE->set_heading(get_string('monitoring_metrics', 'tool_monitoring'));
+$PAGE->set_title(get_string('settings:monitoring_metrics', 'tool_monitoring'));
+$PAGE->set_heading(get_string('settings:monitoring_metrics', 'tool_monitoring'));
 
 $overview = new overview(metrics: $manager->metrics, tags: $manager->tags);
 echo $OUTPUT->header();

--- a/lang/en/tool_monitoring.php
+++ b/lang/en/tool_monitoring.php
@@ -15,54 +15,61 @@
 // along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Plugin strings are defined here.
+ * English language strings for the component.
  *
- * @package     tool_monitoring
- * @category    string
- * @copyright   2025 MootDACH DevCamp
- *              Daniel Fainberg <d.fainberg@tu-berlin.de>
- *              Martin Gauk <martin.gauk@tu-berlin.de>
- *              Sebastian Rupp <sr@artcodix.com>
- *              Malte Schmitz <mal.schmitz@uni-luebeck.de>
- *              Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
- * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @link https://docs.moodle.org/dev/String_API Moodle docs String API
+ *
+ * @package    tool_monitoring
+ * @copyright  2025 MootDACH DevCamp
+ *             Daniel Fainberg <d.fainberg@tu-berlin.de>
+ *             Martin Gauk <martin.gauk@tu-berlin.de>
+ *             Sebastian Rupp <sr@artcodix.com>
+ *             Malte Schmitz <mal.schmitz@uni-luebeck.de>
+ *             Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$string['actions'] = 'Actions';
-$string['component'] = 'Component';
-$string['configure'] = 'Configure';
-$string['configure_metric'] = 'Configure Metric';
-$string['courses_description'] = 'Current number of courses';
-$string['description'] = 'Description';
-$string['edit_tag'] = 'Edit tag {$a}';
 $string['error:quiz_attempts_in_progress_config:input_invalid'] = 'Invalid input';
 $string['error:users_online_config:timewindows_invalid'] = 'Invalid time window(s) provided: {$a}';
+
+$string['event:metric_config_updated'] = 'Metric configuration updated';
 $string['event:metric_disabled'] = 'Metric disabled';
 $string['event:metric_enabled'] = 'Metric enabled';
-$string['manage_tags'] = 'Manage tags';
+
+$string['metric:courses_description'] = 'Current number of courses';
+$string['metric:overdue_tasks_description'] = 'Number of tasks (excluding disabled ones) for which the next runtime is not in the future';
 $string['metric:quiz_attempts_in_progress_config:maxdeadlineseconds'] = 'Maximum deadline time';
 $string['metric:quiz_attempts_in_progress_config:maxdeadlineseconds_help'] = 'Do not count attempts that have a deadline in more than this number of seconds.';
 $string['metric:quiz_attempts_in_progress_config:maxidleseconds'] = 'Maximum idle time';
 $string['metric:quiz_attempts_in_progress_config:maxidleseconds_help'] = 'Do not count attempts that are idle longer than this number of seconds.';
-$string['metricconfigupdated'] = 'Metric configuration updated';
-$string['metricenabled'] = 'Metric enabled';
-$string['metricsoverview'] = 'Overview of Available Metrics';
-$string['metricsoverviewshowall'] = 'Show all metrics';
+$string['metric:quiz_attempts_in_progress_description'] = 'Number of ongoing quiz attempts with an approaching deadline';
+$string['metric:user_accounts_description'] = 'Current number of user accounts';
+$string['metric:users_online_config:timewindows'] = 'Time window (seconds)';
+$string['metric:users_online_config:timewindows_help'] = 'Number of seconds since the last user access for that user to be counted as online. Multiple values can be specified, separated by commas; the metric will produce a separate metric value for each time window.';
+$string['metric:users_online_description'] = 'Number of users that have recently accessed the site';
+
 $string['monitoring:manage_metrics'] = 'Manage and configure monitoring metrics';
-$string['monitoring_metrics'] = 'Monitoring Metrics';
-$string['name'] = 'Name';
-$string['overdue_tasks_description'] = 'Number of tasks (excluding disabled ones) for which the next runtime is not in the future';
+
 $string['pluginname'] = 'Monitoring';
-$string['quiz_attempts_in_progress_description'] = 'Number of ongoing quiz attempts with an approaching deadline';
+
+$string['settings:actions'] = 'Actions';
+$string['settings:component'] = 'Component';
+$string['settings:configure'] = 'Configure';
+$string['settings:configure_metric'] = 'Configure Metric';
+$string['settings:description'] = 'Description';
+$string['settings:edit_tag'] = 'Edit tag {$a}';
+$string['settings:manage_tags'] = 'Manage tags';
+$string['settings:metric_enabled'] = 'Metric enabled';
+$string['settings:metrics_overview'] = 'Overview of Available Metrics';
+$string['settings:metrics_overview_show_all'] = 'Show all metrics';
+$string['settings:monitoring_metrics'] = 'Monitoring Metrics';
+$string['settings:name'] = 'Name';
+$string['settings:tag_filter'] = 'Filter:';
+$string['settings:type'] = 'Type';
+
 $string['subplugintype_monitoringexporter_plural'] = 'Exporter types';
+
 $string['tagarea_metrics'] = 'Metrics';
 $string['tagcollection_monitoring'] = 'Monitoring';
-$string['tagfilter'] = 'Filter:';
-$string['tags'] = 'Tags';
-$string['type'] = 'Type';
-$string['user_accounts_description'] = 'Current number of user accounts';
-$string['users_online_description'] = 'Number of users that have recently accessed the site';
-$string['users_online_time_windows'] = 'Time window (seconds)';
-$string['users_online_time_windows_help'] = 'Number of seconds since the last user access for that user to be counted as online. Multiple values can be specified, separated by commas; the metric will produce a separate metric value for each time window.';

--- a/settings.php
+++ b/settings.php
@@ -48,7 +48,7 @@ $ADMIN->add(
 
 $overviewlink = new admin_externalpage(
     name: 'monitoringmetricsoverviewlink',
-    visiblename: new lang_string('metricsoverview', 'tool_monitoring'),
+    visiblename: new lang_string('settings:metrics_overview', 'tool_monitoring'),
     url: new moodle_url('/admin/tool/monitoring'),
     req_capability: 'tool/monitoring:manage_metrics',
 );

--- a/templates/configure.mustache
+++ b/templates/configure.mustache
@@ -25,6 +25,6 @@
     }
 }}
 
-<h2>{{#str}} configure_metric, tool_monitoring {{/str}}</h2>
+<h2>{{#str}} settings:configure_metric, tool_monitoring {{/str}}</h2>
 
 {{{form}}}

--- a/templates/overview.mustache
+++ b/templates/overview.mustache
@@ -64,32 +64,32 @@
 }}
 
 <h2>
-    {{#str}} metricsoverview, tool_monitoring {{/str}}
+    {{#str}} settings:metrics_overview, tool_monitoring {{/str}}
 </h2>
 
 {{#has_tags}}
     <div class="mt-3">
-        {{#str}} tagfilter, tool_monitoring {{/str}}
+        {{#str}} settings:tag_filter, tool_monitoring {{/str}}
         {{#tags}}
             <a href="{{remove_url}}" class="badge bg-secondary text-dark" style="font-size: 100%;"><span aria-hidden="true">× </span> {{name}}</a>
         {{/tags}}
     </div>
     <div class="text-end mb-3">
-        <a href="{{all_metrics_url}}">{{#str}} metricsoverviewshowall, tool_monitoring {{/str}}</a>
+        <a href="{{all_metrics_url}}">{{#str}} settings:metrics_overview_show_all, tool_monitoring {{/str}}</a>
     </div>
 {{/has_tags}}
 
 <table class="table table-sm table-striped table-hover generaltable">
   <thead>
     <tr>
-      <th scope="col">{{#str}} component, tool_monitoring {{/str}}</th>
-      <th scope="col">{{#str}} name, tool_monitoring {{/str}}</th>
-      <th scope="col">{{#str}} type, tool_monitoring {{/str}}</th>
-      <th scope="col">{{#str}} description, tool_monitoring {{/str}}</th>
+      <th scope="col">{{#str}} settings:component, tool_monitoring {{/str}}</th>
+      <th scope="col">{{#str}} settings:name, tool_monitoring {{/str}}</th>
+      <th scope="col">{{#str}} settings:type, tool_monitoring {{/str}}</th>
+      <th scope="col">{{#str}} settings:description, tool_monitoring {{/str}}</th>
       {{#is_tagging_enabled}}
-        <th scope="col">{{#str}} tags, tool_monitoring {{/str}}</th>
+        <th scope="col">{{#str}} tags {{/str}}</th>
       {{/is_tagging_enabled}}
-      <th scope="col">{{#str}} actions, tool_monitoring {{/str}}</th>
+      <th scope="col">{{#str}} settings:actions, tool_monitoring {{/str}}</th>
     </tr>
   </thead>
   <tbody>
@@ -107,7 +107,7 @@
           </td>
         {{/is_tagging_enabled}}
         <td>
-            <a href="{{{config_url}}}" class="icon-no-margin me-1 d-inline-block">{{#pix}}i/settings, core, {{#str}} configure, tool_monitoring {{/str}}{{/pix}}</a>
+            <a href="{{{config_url}}}" class="icon-no-margin me-1 d-inline-block">{{#pix}}i/settings, core, {{#str}} settings:configure, tool_monitoring {{/str}}{{/pix}}</a>
             <a href="#" class="icon-no-margin d-inline-block" data-action="toggle-metric" data-metric="{{qualified_name}}" data-enabled="{{#enabled}}1{{/enabled}}{{^enabled}}0{{/enabled}}">
                 <span data-region="enabled-icon"{{^enabled}} class="d-none"{{/enabled}}>{{#pix}}t/hide, core, {{#str}} disable {{/str}}{{/pix}}</span>
                 <span data-region="disabled-icon"{{#enabled}} class="d-none"{{/enabled}}>{{#pix}}t/show, core, {{#str}} enable {{/str}}{{/pix}}</span>
@@ -121,9 +121,9 @@
 {{#is_tagging_enabled}}
     <div class="my-5 text-end">
         {{#tags}}
-            <a href="{{edit_url}}" class="btn btn-secondary">{{#str}} edit_tag, tool_monitoring, {{name}} {{/str}}</a>
+            <a href="{{edit_url}}" class="btn btn-secondary">{{#str}} settings:edit_tag, tool_monitoring, {{name}} {{/str}}</a>
         {{/tags}}
-        <a href="{{manage_tags_url}}" class="btn btn-secondary">{{#str}} manage_tags, tool_monitoring {{/str}}</a>
+        <a href="{{manage_tags_url}}" class="btn btn-secondary">{{#str}} settings:manage_tags, tool_monitoring {{/str}}</a>
     </div>
 {{/is_tagging_enabled}}
 

--- a/tests/local/metrics/courses_test.php
+++ b/tests/local/metrics/courses_test.php
@@ -58,7 +58,7 @@ final class courses_test extends advanced_testcase {
     public function test_get_description(): void {
         $metric = new courses();
         $description = $metric->get_description();
-        self::assertSame('courses_description', $description->get_identifier());
+        self::assertSame('metric:courses_description', $description->get_identifier());
         self::assertSame('tool_monitoring', $description->get_component());
     }
 

--- a/tests/local/metrics/overdue_tasks_test.php
+++ b/tests/local/metrics/overdue_tasks_test.php
@@ -69,7 +69,7 @@ final class overdue_tasks_test extends advanced_testcase {
     public function test_get_description(): void {
         $metric = new overdue_tasks();
         $description = $metric->get_description();
-        self::assertSame('overdue_tasks_description', $description->get_identifier());
+        self::assertSame('metric:overdue_tasks_description', $description->get_identifier());
         self::assertSame('tool_monitoring', $description->get_component());
     }
 

--- a/tests/local/metrics/quiz_attempts_in_progress_test.php
+++ b/tests/local/metrics/quiz_attempts_in_progress_test.php
@@ -59,7 +59,7 @@ final class quiz_attempts_in_progress_test extends advanced_testcase {
     public function test_get_description(): void {
         $metric = new quiz_attempts_in_progress();
         $description = $metric->get_description();
-        self::assertSame('quiz_attempts_in_progress_description', $description->get_identifier());
+        self::assertSame('metric:quiz_attempts_in_progress_description', $description->get_identifier());
         self::assertSame('tool_monitoring', $description->get_component());
     }
 

--- a/tests/local/metrics/user_accounts_test.php
+++ b/tests/local/metrics/user_accounts_test.php
@@ -58,7 +58,7 @@ final class user_accounts_test extends advanced_testcase {
     public function test_get_description(): void {
         $metric = new user_accounts();
         $description = $metric->get_description();
-        self::assertSame('user_accounts_description', $description->get_identifier());
+        self::assertSame('metric:user_accounts_description', $description->get_identifier());
         self::assertSame('tool_monitoring', $description->get_component());
     }
 

--- a/tests/local/metrics/users_online_config_test.php
+++ b/tests/local/metrics/users_online_config_test.php
@@ -215,13 +215,13 @@ final class users_online_config_test extends advanced_testcase {
         $mockconfigform = $this->createMock(config_form::class);
         $mockmform->expects($this->once())
             ->method('addElement')
-            ->with('text', 'timewindows', new lang_string('users_online_time_windows', 'tool_monitoring'));
+            ->with('text', 'timewindows', new lang_string('metric:users_online_config:timewindows', 'tool_monitoring'));
         $mockmform->expects($this->once())
             ->method('setType')
             ->with('timewindows', PARAM_TEXT);
         $mockmform->expects($this->once())
             ->method('addHelpButton')
-            ->with('timewindows', 'users_online_time_windows', 'tool_monitoring');
+            ->with('timewindows', 'metric:users_online_config:timewindows', 'tool_monitoring');
         $mockmform->expects($this->once())
             ->method('addRule')
             ->with('timewindows', null, 'required', null, 'client');

--- a/tests/local/metrics/users_online_test.php
+++ b/tests/local/metrics/users_online_test.php
@@ -58,7 +58,7 @@ final class users_online_test extends advanced_testcase {
     public function test_get_description(): void {
         $metric = new users_online();
         $description = $metric->get_description();
-        self::assertSame('users_online_description', $description->get_identifier());
+        self::assertSame('metric:users_online_description', $description->get_identifier());
         self::assertSame('tool_monitoring', $description->get_component());
     }
 


### PR DESCRIPTION
- Almost all string IDs use namespacing/scoping via colons.
- Currently the prefixes `error:`, `event:`, `metric:`, and `settings:` exist.
- The remaining ones are forced to follow a certain pattern by Moodle.
- Word separation via underscores is used consistently (wherever possible).
- Metric descriptions match metric names exactly and have a `metric:` prefix and `_description` suffix.
- Metric config options also have the `metric:` prefix, followed by the config class name and another colon, followed by the actual option name.

---

Supersedes #50. It ended up being easier for me to just re-write it as a new commit/branch, rather than attempt to properly rebase the ones in #50 and solve the conflicts that accumulated over time.