### PR TITLE
Cleanup and improve admin settings navigation

### DIFF
--- a/classes/plugininfo/monitoringexporter.php
+++ b/classes/plugininfo/monitoringexporter.php
@@ -70,7 +70,7 @@ class monitoringexporter extends base {
     #[\Override]
     public function load_settings(part_of_admin_tree $adminroot, $parentnodename, $hassiteconfig): void {
         global $ADMIN;
-        /** @var admin_root $ADMIN */
+
         if (!$this->is_installed_and_upgraded()) {
             return;
         }
@@ -86,6 +86,7 @@ class monitoringexporter extends base {
         include($this->full_path('settings.php'));
         if ($settings->settings != new stdClass()) {
             // Only if settings were actually added to the page, do we want to add it to the tree.
+            /** @var admin_root $ADMIN */
             $ADMIN->add($parentnodename, $settings);
         }
     }

--- a/classes/plugininfo/monitoringexporter.php
+++ b/classes/plugininfo/monitoringexporter.php
@@ -69,9 +69,8 @@ class monitoringexporter extends base {
      */
     #[\Override]
     public function load_settings(part_of_admin_tree $adminroot, $parentnodename, $hassiteconfig): void {
-        global $ADMIN, $CFG;
+        global $ADMIN;
         /** @var admin_root $ADMIN */
-        require_once("$CFG->dirroot/mod/assign/adminlib.php");
         if (!$this->is_installed_and_upgraded()) {
             return;
         }

--- a/configure.php
+++ b/configure.php
@@ -34,20 +34,18 @@ use tool_monitoring\metrics_manager;
 use tool_monitoring\output\configure;
 
 require_once(__DIR__ . '/../../../config.php');
+require_once($CFG->libdir . '/adminlib.php');
 
 global $OUTPUT, $PAGE;
 
 require_login();
 
-$context = context_system::instance();
-require_capability('tool/monitoring:manage_metrics', $context);
+require_capability('tool/monitoring:manage_metrics', context_system::instance());
 
 $qualifiedname = required_param('metric', PARAM_ALPHAEXT);
+admin_externalpage_setup('tool_monitoring_overview');
+$PAGE->set_secondary_active_tab('modules');
 $PAGE->set_url('/admin/tool/monitoring/configure.php', ['metric' => $qualifiedname]);
-$PAGE->set_context($context);
-$PAGE->set_title(get_string('settings:monitoring_metrics', 'tool_monitoring'));
-$PAGE->set_heading(get_string('settings:monitoring_metrics', 'tool_monitoring'));
-$PAGE->add_body_class('limitedwidth');
 
 $manager = new metrics_manager();
 $metric = $manager->sync(delete: true)->metrics[$qualifiedname] ?? null;

--- a/index.php
+++ b/index.php
@@ -33,13 +33,13 @@ use tool_monitoring\metrics_manager;
 use tool_monitoring\output\overview;
 
 require_once(__DIR__ . '/../../../config.php');
+require_once($CFG->libdir . '/adminlib.php');
 
 global $PAGE, $OUTPUT;
 
 require_login();
 
-$context = context_system::instance();
-require_capability('tool/monitoring:manage_metrics', $context);
+require_capability('tool/monitoring:manage_metrics', context_system::instance());
 
 // Handle tags parameter for filtering of multiple tags.
 $taglist = optional_param('tag', '', PARAM_TAGLIST);
@@ -54,10 +54,9 @@ if ($taglist) {
     $tags = [];
 }
 
+admin_externalpage_setup('tool_monitoring_overview');
+$PAGE->set_secondary_active_tab('modules');
 $PAGE->set_url('/admin/tool/monitoring/', $params);
-$PAGE->set_context($context);
-$PAGE->set_title(get_string('settings:monitoring_metrics', 'tool_monitoring'));
-$PAGE->set_heading(get_string('settings:monitoring_metrics', 'tool_monitoring'));
 
 $overview = new overview(metrics: $manager->metrics, tags: $manager->tags);
 echo $OUTPUT->header();

--- a/lang/en/tool_monitoring.php
+++ b/lang/en/tool_monitoring.php
@@ -71,7 +71,6 @@ $string['settings:manage_tags'] = 'Manage tags';
 $string['settings:metric_enabled'] = 'Metric enabled';
 $string['settings:metrics_overview'] = 'Overview of Available Metrics';
 $string['settings:metrics_overview_show_all'] = 'Show all metrics';
-$string['settings:monitoring_metrics'] = 'Monitoring Metrics';
 $string['settings:name'] = 'Name';
 $string['settings:tag_filter'] = 'Filter:';
 $string['settings:type'] = 'Type';

--- a/settings.php
+++ b/settings.php
@@ -37,13 +37,13 @@ use tool_monitoring\plugininfo\monitoringexporter;
 defined('MOODLE_INTERNAL') || die;
 
 global $ADMIN;
-/** @var admin_root $ADMIN */
 
 // Create a top-level plugin category and add it under the admin tools super-category.
 $monitoringcategory = new admin_category(
     name: 'tool_monitoring',
     visiblename: new lang_string('pluginname', 'tool_monitoring'),
 );
+/** @var admin_root $ADMIN */
 $ADMIN->add('tools', $monitoringcategory);
 
 // Create a link to the metrics overview page and add it as the first item in the monitoring category.

--- a/settings.php
+++ b/settings.php
@@ -36,9 +36,8 @@ use tool_monitoring\plugininfo\monitoringexporter;
 
 defined('MOODLE_INTERNAL') || die;
 
-global $ADMIN, $CFG;
+global $ADMIN;
 /** @var admin_root $ADMIN */
-require_once("$CFG->dirroot/mod/assign/adminlib.php");
 
 // Create a top-level plugin category and add it under the admin tools super-category.
 $monitoringcategory = new admin_category(

--- a/settings.php
+++ b/settings.php
@@ -41,29 +41,29 @@ global $ADMIN;
 
 // Create a top-level plugin category and add it under the admin tools super-category.
 $monitoringcategory = new admin_category(
-    name: 'tool_monitoring_category',
+    name: 'tool_monitoring',
     visiblename: new lang_string('pluginname', 'tool_monitoring'),
 );
 $ADMIN->add('tools', $monitoringcategory);
 
 // Create a link to the metrics overview page and add it as the first item in the monitoring category.
 $overviewlink = new admin_externalpage(
-    name: 'monitoringmetricsoverviewlink',
+    name: 'tool_monitoring_overview',
     visiblename: new lang_string('settings:metrics_overview', 'tool_monitoring'),
     url: new moodle_url('/admin/tool/monitoring'),
     req_capability: 'tool/monitoring:manage_metrics',
 );
-$ADMIN->add('tool_monitoring_category', $overviewlink);
+$ADMIN->add('tool_monitoring', $overviewlink);
 
 // As the second item in the monitoring category, group all settings pages for the exporters.
 $monitoringexportercategory = new admin_category(
-    name: 'monitoringexporter_category',
+    name: 'tool_monitoring_exporters',
     visiblename: new lang_string('settings:exporters', 'tool_monitoring'),
 );
-$ADMIN->add('tool_monitoring_category', $monitoringexportercategory);
+$ADMIN->add('tool_monitoring', $monitoringexportercategory);
 
 // Underneath the exporter category, add all exporter settings pages.
 /** @var monitoringexporter $subplugin */
 foreach (core_plugin_manager::instance()->get_plugins_of_type('monitoringexporter') as $subplugin) {
-    $subplugin->load_settings($ADMIN, 'monitoringexporter_category', $hassiteconfig);
+    $subplugin->load_settings($ADMIN, 'tool_monitoring_exporters', $hassiteconfig);
 }


### PR DESCRIPTION
This pull requests performs some refactoring to clean the code and optimise the UI of the admin settings navigation tree:

* `require_once("$CFG->dirroot/mod/assign/adminlib.php")` is not needed. We do not need a library from `mod_assign`.
* I tried to make the names of the admin tree nodes more consistent and tried to following the implicit Moodle conventions:
   * `tool_monitoring` is the category
      * `tool_monitoring_overview` is the external page with the overview table
      * `tool_monitoring_exporters` is the category for the exporters
* The admin external page now uses `admin_externalpage_setup('tool_monitoring_overview')` and `$PAGE->set_secondary_active_tab('modules')` to correctly setup this page as an admin external page. As a result the title, header, breadcrumb navigation and the active indicator in the secondary navigation are now shown correctly. See below for a before and after screenshot.

Before:
<img width="600" src="https://github.com/user-attachments/assets/b567fb20-e20b-48ea-856f-d1e7fd05304d" />

After:
<img width="600" src="https://github.com/user-attachments/assets/0ee086f3-6906-4a91-8286-e44d888cc6fe" />

Our admin category for comparison:
<img width="600" src="https://github.com/user-attachments/assets/9b0aa075-0c23-4597-af14-3eb287ec71fe" />

Our metrics overview admin external page now has the same look and feel as the regular admin category page.