### PR TITLE
rename tag itemtype to table name

### DIFF
--- a/classes/form/config.php
+++ b/classes/form/config.php
@@ -86,7 +86,7 @@ class config extends moodleform {
             label: new lang_string('settings:metric_enabled', 'tool_monitoring'),
         );
         $this->add_tags_field(
-            itemtype: 'metrics',
+            itemtype: registered_metric::TABLE,
             component: 'tool_monitoring',
         );
         if (!is_null($this->metric->configclass)) {

--- a/classes/metrics_manager.php
+++ b/classes/metrics_manager.php
@@ -148,7 +148,7 @@ final class metrics_manager {
         $where = '(m.component,m.name) IN (' . implode(',', $inplaceholders) . ')';
         $join = '';
         // Filter by tags.
-        $tagsenabled = core_tag_tag::is_enabled('tool_monitoring', 'metrics');
+        $tagsenabled = core_tag_tag::is_enabled('tool_monitoring', registered_metric::TABLE);
         if ($tagsenabled) {
             if (!empty($tagnames)) {
                 $tagcollid = $DB->get_field('tag_coll', 'id', ['name' => 'monitoring', 'component' => 'tool_monitoring']);
@@ -163,7 +163,7 @@ final class metrics_manager {
                 $params += $inparams;
                 $params += [
                     'tagcomponent' => 'tool_monitoring',
-                    'tagitemtype' => 'metrics',
+                    'tagitemtype' => registered_metric::TABLE,
                     'tagcount' => count($tagids),
                 ];
                 $subselect = "SELECT ti.itemid
@@ -252,7 +252,7 @@ final class metrics_manager {
             // Optionally, delete the former and insert the latter.
             if ($delete) {
                 foreach ($existingrecords as $record) {
-                    core_tag_tag::remove_all_item_tags('tool_monitoring', 'metrics', $record->id);
+                    core_tag_tag::remove_all_item_tags('tool_monitoring', registered_metric::TABLE, $record->id);
                 }
                 [$oprphansql, $orphanparams] = $DB->get_in_or_equal(array_column($existingrecords, 'id'), onemptyitems: null);
                 $DB->delete_records_select(registered_metric::TABLE, "id $oprphansql", $orphanparams);

--- a/classes/output/overview.php
+++ b/classes/output/overview.php
@@ -108,7 +108,7 @@ final readonly class overview implements renderable, templatable {
     public function export_for_template(renderer_base $output): array {
         global $DB;
         $tagcollid = $DB->get_field('tag_coll', 'id', ['name' => 'monitoring', 'component' => 'tool_monitoring']);
-        $tagsenabled = core_tag_tag::is_enabled('tool_monitoring', 'metrics');
+        $tagsenabled = core_tag_tag::is_enabled('tool_monitoring', registered_metric::TABLE);
         $managetagsurl = new moodle_url('/tag/manage.php', ['tc' => $tagcollid]);
         $lines = [];
         foreach ($this->metrics as $qualifiedname => $metric) {
@@ -123,7 +123,7 @@ final readonly class overview implements renderable, templatable {
                 'config_url' => $configurl->out(escaped: false),
             ];
             if ($tagsenabled) {
-                $tags = core_tag_tag::get_item_tags('tool_monitoring', 'metrics', $metric->id);
+                $tags = core_tag_tag::get_item_tags('tool_monitoring', registered_metric::TABLE, $metric->id);
                 $line['tags'] = array_map(
                     fn (core_tag_tag $tag): array => [
                         'id' => $tag->id,

--- a/classes/registered_metric.php
+++ b/classes/registered_metric.php
@@ -255,7 +255,7 @@ final class registered_metric implements IteratorAggregate {
             $formdata = [];
         }
         $formdata['enabled'] = $this->enabled;
-        $formdata['tags'] = core_tag_tag::get_item_tags_array('tool_monitoring', 'metrics', $this->id);
+        $formdata['tags'] = core_tag_tag::get_item_tags_array('tool_monitoring', self::TABLE, $this->id);
         return $formdata;
     }
 
@@ -292,7 +292,7 @@ final class registered_metric implements IteratorAggregate {
         // This only actually performs DB queries if tags were either added, removed, or their order changed.
         core_tag_tag::set_item_tags(
             component: 'tool_monitoring',
-            itemtype: 'metrics',
+            itemtype: self::TABLE,
             itemid: $this->id,
             context: context_system::instance(),
             tagnames: $formdata->tags

--- a/db/tag.php
+++ b/db/tag.php
@@ -31,9 +31,11 @@
 
 defined('MOODLE_INTERNAL') || die();
 
+use tool_monitoring\registered_metric;
+
 $tagareas = [
     [
-        'itemtype' => 'metrics',
+        'itemtype' => registered_metric::TABLE,
         'customurl' => '/admin/tool/monitoring/',
         'collection' => 'monitoring',
         'searchable' => false,

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
 
 /**
- * Plugin version and other meta-data are defined here.
+ * Upgrade steps for tool_monitoring.
  *
  * @package    tool_monitoring
  * @copyright  2025 MootDACH DevCamp
@@ -25,14 +25,45 @@
  *             Malte Schmitz <mal.schmitz@uni-luebeck.de>
  *             Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
  * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- *
- * {@noinspection PhpUndefinedVariableInspection}
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->component = 'tool_monitoring';
-$plugin->release = '0.2.2';
-$plugin->version = 2026041000;
-$plugin->requires = 2025041400; // Moodle 5.0.
-$plugin->maturity = MATURITY_ALPHA;
+use tool_monitoring\registered_metric;
+
+/**
+ * Upgrade code for the monitoring tool.
+ *
+ * @param int $oldversion
+ * @return bool
+ * @throws ddl_exception
+ * @throws dml_exception
+ */
+function xmldb_tool_monitoring_upgrade(int $oldversion): bool {
+    global $DB;
+
+    if ($oldversion < 2026041000) {
+        $transaction = $DB->start_delegated_transaction();
+
+        // The tag itemtype must match an existing DB table name. Older versions used "metrics",
+        // but the actual records live in "tool_monitoring_metrics", so migrate both area and instances.
+        $DB->set_field(
+            'tag_area',
+            'itemtype',
+            registered_metric::TABLE,
+            ['component' => 'tool_monitoring', 'itemtype' => 'metrics']
+        );
+        $DB->set_field(
+            'tag_instance',
+            'itemtype',
+            registered_metric::TABLE,
+            ['component' => 'tool_monitoring', 'itemtype' => 'metrics']
+        );
+
+        $transaction->allow_commit();
+
+        upgrade_plugin_savepoint(true, 2026041000, 'tool', 'monitoring');
+    }
+
+    return true;
+}

--- a/lang/en/tool_monitoring.php
+++ b/lang/en/tool_monitoring.php
@@ -77,7 +77,7 @@ $string['settings:type'] = 'Type';
 
 $string['subplugintype_monitoringexporter_plural'] = 'Exporter types';
 
-$string['tagarea_metrics'] = 'Metrics';
+$string['tagarea_tool_monitoring_metrics'] = 'Metrics';
 $string['tagcollection_monitoring'] = 'Monitoring';
 
 $string['testing:metric:testing_simple_metric_config:notpromotedstring'] = 'String with a default; not promoted to any property.';

--- a/tests/behat/behat_tool_monitoring.php
+++ b/tests/behat/behat_tool_monitoring.php
@@ -30,6 +30,7 @@
  */
 
 use Behat\Step\Given;
+use tool_monitoring\registered_metric;
 
 require_once(__DIR__ . '/../../../../../lib/behat/behat_base.php');
 
@@ -66,7 +67,7 @@ class behat_tool_monitoring extends behat_base {
         };
         $area = $DB->get_record(
             table: 'tag_area',
-            conditions: ['itemtype' => 'metrics', 'component' => 'tool_monitoring'],
+            conditions: ['itemtype' => registered_metric::TABLE, 'component' => 'tool_monitoring'],
             strictness: MUST_EXIST,
         );
         core_tag_area::update($area, ['enabled' => $enabled]);

--- a/tests/metrics_manager_test.php
+++ b/tests/metrics_manager_test.php
@@ -553,7 +553,7 @@ final class metrics_manager_test extends advanced_testcase {
         // Add tags alpha and beta to metric foo.
         core_tag_tag::set_item_tags(
             component: 'tool_monitoring',
-            itemtype: 'metrics',
+            itemtype: registered_metric::TABLE,
             itemid: $metricid,
             context: context_system::instance(),
             tagnames: ['alpha', 'beta'],
@@ -562,7 +562,7 @@ final class metrics_manager_test extends advanced_testcase {
             2,
             $DB->count_records('tag_instance', [
                 'component' => 'tool_monitoring',
-                'itemtype' => 'metrics',
+                'itemtype' => registered_metric::TABLE,
                 'itemid' => $metricid,
             ]),
         );
@@ -577,10 +577,10 @@ final class metrics_manager_test extends advanced_testcase {
             0,
             $DB->count_records('tag_instance', [
                 'component' => 'tool_monitoring',
-                'itemtype' => 'metrics',
+                'itemtype' => registered_metric::TABLE,
                 'itemid' => $metricid,
             ]),
         );
-        self::assertSame([], core_tag_tag::get_item_tags_array('tool_monitoring', 'metrics', $metricid));
+        self::assertSame([], core_tag_tag::get_item_tags_array('tool_monitoring', registered_metric::TABLE, $metricid));
     }
 }


### PR DESCRIPTION
This closes #79 by renaming the tag itemtype from `metrics` to `registered_metric::TABLE` i.e. `tool_monitoring_metrics`.

The upgrade migration performs the renaming directly in the tables `tag_area` and `tag_instance` which allows renaming the tag itemtype without reinstalling the plugin.