### PR TITLE
Implement caching for registered metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Iteration will yield the [`metric_value`][. metric_value] objects.
 
 > [!TIP]
 > You can look at how the Prometheus exporter does this in its [`exporter`][. exporter] class.
-> Its `export` method receives the `metrics_manager::$metrics` array as an argument after the route controller called `fetch` on the manager.
+> The `export` method calls the `filter` method of the `metrics_manager` to get all enabled metrics that match the tags specified in the request.
 
 ## Terminology
 

--- a/README.md
+++ b/README.md
@@ -462,8 +462,8 @@ If you have admin settings to configure, a `settings.php` script placed in the p
 That page will be added under _Plugins_ > _Admin tools_ > _Monitoring_ > _Available Exporters_ and named the same as the sub-plugin.
 
 Since any exporter will need access to the actual metrics available in the system, at some point it should probably make use of the [`metrics_manager`][. metrics_manager].
-Instantiating it and calling its `fetch` method will be enough in most cases.
-That will store all [`registered_metric`][. registered_metric] instances in its `metrics` property.
+Instantiating it and calling its `filter` method will be enough in most cases.
+That returns [`registered_metric`][. registered_metric] instances as an array (indexed by their qualified names).
 
 To calculate and retrieve the current value(s) of a given metric, the associated `registered_metric` instance just needs to be iterated over.
 Iteration will yield the [`metric_value`][. metric_value] objects.

--- a/classes/event/observer.php
+++ b/classes/event/observer.php
@@ -1,0 +1,90 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Definition of the {@see observer} class.
+ *
+ * @package    tool_monitoring
+ * @copyright  2025 MootDACH DevCamp
+ *             Daniel Fainberg <d.fainberg@tu-berlin.de>
+ *             Martin Gauk <martin.gauk@tu-berlin.de>
+ *             Sebastian Rupp <sr@artcodix.com>
+ *             Malte Schmitz <mal.schmitz@uni-luebeck.de>
+ *             Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_monitoring\event;
+
+use core\event\tag_added;
+use core\event\tag_created;
+use core\event\tag_deleted;
+use core\event\tag_removed;
+use core\event\tag_updated;
+use core\exception\coding_exception;
+use core_cache\cache;
+use dml_exception;
+use tool_monitoring\local\metrics_cache;
+use tool_monitoring\metric_tag;
+use tool_monitoring\registered_metric;
+
+/**
+ * Provides callbacks for events observed by the plugin.
+ *
+ * **This class is not part of the public API.**
+ *
+ * @link https://docs.moodle.org/dev/Events_API#Event_observers Events API documentation
+ *
+ * @package    tool_monitoring
+ * @copyright  2025 MootDACH DevCamp
+ *             Daniel Fainberg <d.fainberg@tu-berlin.de>
+ *             Martin Gauk <martin.gauk@tu-berlin.de>
+ *             Sebastian Rupp <sr@artcodix.com>
+ *             Malte Schmitz <mal.schmitz@uni-luebeck.de>
+ *             Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class observer {
+    /**
+     * Ensures the metric associated with the added/removed tag instance is removed from the cache.
+     *
+     * @param tag_added|tag_removed $event Event object.
+     * @throws coding_exception
+     * @throws dml_exception
+     */
+    public static function tag_instance_added_or_removed(tag_added|tag_removed $event): void {
+        global $DB;
+        if ($event->other['itemtype'] !== metric_tag::ITEM_TYPE) {
+            return;
+        }
+        $sqlqname = $DB->sql_concat_join(separator: "'_'", elements: ['component', 'name']);
+        $qname = $DB->get_field(registered_metric::TABLE, $sqlqname, ['id' => $event->other['itemid']]);
+        metrics_cache::delete($qname);
+    }
+
+    /**
+     * Ensures the referenced tag is removed from the cache.
+     *
+     * This invalidates a cache entry with the same name when a tag is deleted or updated, but also when a new tag is created
+     * because we are doing null-caching in {@see metric_tag::get_all_with_names}.
+     *
+     * @param tag_created|tag_deleted|tag_updated $event Event object.
+     * @throws coding_exception
+     */
+    public static function tag_created_or_deleted_or_updated(tag_created|tag_deleted|tag_updated $event): void {
+        cache::make('tool_monitoring', 'metric_tags')->delete($event->other['name']);
+    }
+}

--- a/classes/event/observer.php
+++ b/classes/event/observer.php
@@ -86,5 +86,10 @@ final class observer {
      */
     public static function tag_created_or_deleted_or_updated(tag_created|tag_deleted|tag_updated $event): void {
         cache::make('tool_monitoring', 'metric_tags')->delete($event->other['name']);
+        if ($event instanceof tag_updated) {
+            // If a tag is renamed, instances of that tag carried by registered metrics become invalid.
+            // TODO: Query the DB for the actual metrics carrying the updated tag and only remove those from the cache.
+            metrics_cache::purge();
+        }
     }
 }

--- a/classes/exceptions/metric_not_found.php
+++ b/classes/exceptions/metric_not_found.php
@@ -15,9 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Registration of metrics via the Hooks API.
- *
- * @link https://moodledev.io/docs/apis/core/hooks#registering-of-hook-callbacks API Documentation
+ * Definition of the {@see metric_not_found} class.
  *
  * @package    tool_monitoring
  * @copyright  2025 MootDACH DevCamp
@@ -29,17 +27,30 @@
  * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use core\hook\di_configuration;
-use tool_monitoring\hook\metric_collection;
-use tool_monitoring\local\metrics;
+namespace tool_monitoring\exceptions;
 
-defined('MOODLE_INTERNAL') || die();
-
-$callbacks = [
-    ['hook' => di_configuration::class, 'callback' => [metric_collection::class, 'configure_dependency_injection']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\courses::class, 'collect']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\overdue_tasks::class, 'collect']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\quiz_attempts_in_progress::class, 'collect']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\user_accounts::class, 'collect']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\users_online::class, 'collect']],
-];
+/**
+ * No metric with the given qualified name is registered.
+ *
+ * @package    tool_monitoring
+ * @copyright  2025 MootDACH DevCamp
+ *             Daniel Fainberg <d.fainberg@tu-berlin.de>
+ *             Martin Gauk <martin.gauk@tu-berlin.de>
+ *             Sebastian Rupp <sr@artcodix.com>
+ *             Malte Schmitz <mal.schmitz@uni-luebeck.de>
+ *             Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class metric_not_found extends tool_monitoring_exception {
+    /**
+     * Passes the arguments through to the parent constructor as the {@see parent::$a `a`} context.
+     *
+     * @param string $qualifiedname Name of the missing metric.
+     */
+    public function __construct(
+        /** @var string Name of the missing metric. */
+        public readonly string $qualifiedname,
+    ) {
+        parent::__construct(a: ['qualifiedname' => $qualifiedname]);
+    }
+}

--- a/classes/external/set_metric_enabled.php
+++ b/classes/external/set_metric_enabled.php
@@ -30,6 +30,7 @@
 namespace tool_monitoring\external;
 
 use context_system;
+use core\di;
 use core\exception\coding_exception;
 use core_external\external_api;
 use core_external\external_function_parameters;
@@ -38,6 +39,7 @@ use core_external\external_value;
 use core_external\restricted_context_exception;
 use dml_exception;
 use invalid_parameter_exception;
+use JsonException;
 use required_capability_exception;
 use tool_monitoring\metrics_manager;
 
@@ -77,6 +79,7 @@ final class set_metric_enabled extends external_api {
      * @throws invalid_parameter_exception
      * @throws required_capability_exception
      * @throws restricted_context_exception
+     * @throws JsonException A metric is configurable but it's default config could not be serialized.
      */
     public static function execute(string $qualifiedname, bool $enabled): array {
         ['metric' => $qualifiedname, 'enabled' => $enabled] = self::validate_parameters(
@@ -89,8 +92,7 @@ final class set_metric_enabled extends external_api {
         $context = context_system::instance();
         self::validate_context($context);
         require_capability('tool/monitoring:manage_metrics', $context);
-        $manager = new metrics_manager();
-        $metric = $manager->sync()->metrics[$qualifiedname] ?? null;
+        $metric = di::get(metrics_manager::class)->sync()[$qualifiedname] ?? null;
         if (is_null($metric)) {
             throw new invalid_parameter_exception("Unknown metric '$qualifiedname'.");
         }

--- a/classes/form/config.php
+++ b/classes/form/config.php
@@ -34,6 +34,7 @@ use core\lang_string;
 use dml_exception;
 use JsonException;
 use moodleform;
+use tool_monitoring\metric_tag;
 use tool_monitoring\registered_metric;
 
 defined('MOODLE_INTERNAL') || die();
@@ -86,7 +87,7 @@ class config extends moodleform {
             label: new lang_string('settings:metric_enabled', 'tool_monitoring'),
         );
         $this->add_tags_field(
-            itemtype: registered_metric::TABLE,
+            itemtype: metric_tag::ITEM_TYPE,
             component: 'tool_monitoring',
         );
         if (!is_null($this->metric->configclass)) {

--- a/classes/hook/metric_collection.php
+++ b/classes/hook/metric_collection.php
@@ -33,6 +33,9 @@ namespace tool_monitoring\hook;
 
 use core\attribute\label;
 use core\attribute\tags;
+use core\di;
+use core\hook\di_configuration;
+use core\hook\manager as hook_manager;
 use IteratorAggregate;
 use tool_monitoring\metric;
 use Traversable;
@@ -41,6 +44,8 @@ use Traversable;
  * Hook for collecting {@see metric}s defined in different components throughout the system.
  *
  * A callback can use the {@see self::add} method to add a metric instance to the collection.
+ *
+ * An instance of this hook is dispatched automatically when injected as a dependency by the DI container.
  *
  * @link https://moodledev.io/docs/apis/core/hooks#hook-instance Documentation: Hook instance
  *
@@ -78,5 +83,23 @@ final class metric_collection implements IteratorAggregate {
         foreach ($this->metrics as $metric) {
             yield $metric;
         }
+    }
+
+    /**
+     * Supplies a definition for the class to Moodle's dependency injection container.
+     *
+     * This ensures that the hook is always emitted/dispatched by the DI container first before it is injected as a dependency.
+     *
+     * @link https://moodledev.io/docs/apis/core/hooks#hook-emitter Documentation: Hook emitter
+     * @link https://moodledev.io/docs/apis/core/di#configuring-dependencies Documentation: Dependency injection
+     */
+    public static function configure_dependency_injection(di_configuration $hook): void {
+        $hook->add_definition(
+            id: self::class,
+            // CAUTION: Due to fascinating interplay between how PHP-DI compiles the container and poor error handling in Moodle,
+            // the closure **must** use the actual class name, both in the return type annotation and during construction!
+            // Otherwise, Behat tests will fail without any visible traceback.
+            definition: fn(): metric_collection => di::get(hook_manager::class)->dispatch(new metric_collection()),
+        );
     }
 }

--- a/classes/hook/metric_collection.php
+++ b/classes/hook/metric_collection.php
@@ -61,27 +61,46 @@ use Traversable;
 #[label('Provides the ability to register custom metrics.')]
 #[tags('metric', 'monitoring', 'tool_monitoring')]
 final class metric_collection implements IteratorAggregate {
-    /** @var metric[] All added metrics. */
+    /** @var array<string, array<string, metric>> All added metrics indexed first by component, then by name. */
     private array $metrics = [];
 
     /**
      * Adds the specified metric to the collection.
      *
+     * If a metric with the same component and name already exists, it will be silently replaced.
+     *
      * @param metric $metric Metric instance to add.
      */
     public function add(metric $metric): void {
-        $this->metrics[] = $metric;
+        $component = $metric::get_component();
+        if (!isset($this->metrics[$component])) {
+            $this->metrics[$component] = [];
+        }
+        $this->metrics[$component][$metric::get_name()] = $metric;
     }
 
     /**
-     * Yields the metrics from the collection in the order they were added.
+     * Returns the metric with the given component and name.
+     *
+     * @param string $component Moodle component name.
+     * @param string $name Metric name.
+     * @return metric|null Metric with the given component and name, or `null` if no such metric was added to the collection.
+     */
+    public function get(string $component, string $name): metric|null {
+        return $this->metrics[$component][$name] ?? null;
+    }
+
+    /**
+     * Yields the metrics from the collection.
      *
      * @return Traversable<metric> Previously added metrics.
      */
     #[\Override]
     public function getIterator(): Traversable {
-        foreach ($this->metrics as $metric) {
-            yield $metric;
+        foreach ($this->metrics as $inner) {
+            foreach ($inner as $metric) {
+                yield $metric;
+            }
         }
     }
 

--- a/classes/local/metrics_cache.php
+++ b/classes/local/metrics_cache.php
@@ -1,0 +1,118 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Definition of the {@see metrics_cache} class.
+ *
+ * @package    tool_monitoring
+ * @copyright  2025 MootDACH DevCamp
+ *             Daniel Fainberg <d.fainberg@tu-berlin.de>
+ *             Martin Gauk <martin.gauk@tu-berlin.de>
+ *             Sebastian Rupp <sr@artcodix.com>
+ *             Malte Schmitz <mal.schmitz@uni-luebeck.de>
+ *             Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_monitoring\local;
+
+use core\exception\coding_exception;
+use core_cache\application_cache;
+use core_cache\cache;
+use tool_monitoring\registered_metric;
+
+/**
+ * Internal cache manager for registered metrics.
+ *
+ * This class is just a wrapper around methods of the {@see cache} class, specifically for {@see registered_metric} objects, for
+ * added convenience and type safety. **It is not part of the public API.**
+ *
+ * @package    tool_monitoring
+ * @copyright  2025 MootDACH DevCamp
+ *             Daniel Fainberg <d.fainberg@tu-berlin.de>
+ *             Martin Gauk <martin.gauk@tu-berlin.de>
+ *             Sebastian Rupp <sr@artcodix.com>
+ *             Malte Schmitz <mal.schmitz@uni-luebeck.de>
+ *             Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class metrics_cache {
+    /**
+     * Returns the underlying cache instance.
+     *
+     * @return application_cache
+     */
+    private static function make(): application_cache {
+        return cache::make('tool_monitoring', 'metrics');
+    }
+
+    /**
+     * Adds/updates the specified metrics in the cache.
+     *
+     * @param registered_metric ...$metrics Metrics to cache. If named arguments are passed, those keys **must** match the qualified
+     *                                      names of the metrics.
+     * @throws coding_exception
+     */
+    public static function set(registered_metric ...$metrics): void {
+        if (array_is_list($metrics)) {
+            $metrics = array_column($metrics, null, 'qualifiedname');
+        }
+        self::make()->set_many($metrics);
+    }
+
+    /**
+     * Returns the metric with the specified qualified name from the cache.
+     *
+     * @param string $qualifiedname Qualified name of the metric to retrieve.
+     * @return registered_metric|null Metric with the specified qualified name, or `null` if no such metric is registered.
+     * @throws coding_exception
+     */
+    public static function get(string $qualifiedname): registered_metric|null {
+        return self::make()->get($qualifiedname);
+    }
+
+    /**
+     * Returns the metrics with the specified qualified names from the cache.
+     *
+     * @param string ...$qualifiednames Qualified names of the metrics to retrieve.
+     * @return array<string, registered_metric|null> Associative array of `$qualifiednames` mapped to {@see registered_metric}
+     *                                               instances and `null` for where no such metrics are registered.
+     * @throws coding_exception
+     */
+    public static function get_many(string ...$qualifiednames): array {
+        return self::make()->get_many($qualifiednames);
+    }
+
+    /**
+     * Deletes the metrics with the specified qualified names from the cache.
+     *
+     * @param string ...$qualifiednames Qualified names of the metrics.
+     * @return int Number of metrics that were deleted from the cache.
+     * @throws coding_exception
+     */
+    public static function delete(string ...$qualifiednames): int {
+        return self::make()->delete_many($qualifiednames);
+    }
+
+    /**
+     * Purges the entire cache.
+     *
+     * @return bool `true` on success, `false` on failure.
+     */
+    public static function purge(): bool {
+        return self::make()->purge();
+    }
+}

--- a/classes/metric_tag.php
+++ b/classes/metric_tag.php
@@ -1,0 +1,269 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Definition of the {@see metric_tag} class.
+ *
+ * @package    tool_monitoring
+ * @copyright  2025 MootDACH DevCamp
+ *             Daniel Fainberg <d.fainberg@tu-berlin.de>
+ *             Martin Gauk <martin.gauk@tu-berlin.de>
+ *             Sebastian Rupp <sr@artcodix.com>
+ *             Malte Schmitz <mal.schmitz@uni-luebeck.de>
+ *             Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_monitoring;
+
+use context_system;
+use core\exception\coding_exception;
+use core\exception\moodle_exception;
+use core_cache\cache;
+use core_cache\cacheable_object_interface;
+use core_tag_area;
+use core_tag_tag;
+use dml_exception;
+use moodle_url;
+use stdClass;
+use tool_monitoring\exceptions\tag_not_found;
+
+/**
+ * Convenience class that maps instances to records in the `tag` table, but only those related to the monitoring tag collection.
+ *
+ * @package    tool_monitoring
+ * @copyright  2025 MootDACH DevCamp
+ *             Daniel Fainberg <d.fainberg@tu-berlin.de>
+ *             Martin Gauk <martin.gauk@tu-berlin.de>
+ *             Sebastian Rupp <sr@artcodix.com>
+ *             Malte Schmitz <mal.schmitz@uni-luebeck.de>
+ *             Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
+ * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class metric_tag extends core_tag_tag implements cacheable_object_interface {
+    /** @var string Name of the associated tag area. */
+    public const ITEM_TYPE = registered_metric::TABLE;
+
+    /** @var string Name of the associated tag collection. */
+    public const COLLECTION_NAME = 'monitoring';
+
+    /** @var string List of fields of interest for fetching from the DB. */
+    private const DB_TABLE_FIELDS = 'name, id, userid, rawname, isstandard, description, descriptionformat, flag, timemodified';
+
+    /** @var array<string, string> Properties of interest that are cached; for convenience, keys and values are the same. */
+    private const CACHE_FIELDS = [
+        'id' => 'id',
+        'userid' => 'userid',
+        'name' => 'name',
+        'rawname' => 'rawname',
+        'isstandard' => 'isstandard',
+        'description' => 'description',
+        'descriptionformat' => 'descriptionformat',
+        'flag' => 'flag',
+        'timemodified' => 'timemodified',
+        'taginstanceid' => 'taginstanceid',
+        'taginstancecontextid' => 'taginstancecontextid',
+    ];
+
+    /**
+     * Returns the ID of the tag collection associated with our {@see self::ITEM_TYPE `ITEM_TYPE`}.
+     *
+     * @return int Tag collection ID.
+     * @throws coding_exception Tag area for our {@see self::ITEM_TYPE `ITEM_TYPE`} not found.
+     */
+    public static function get_collection_id(): int {
+        // This function caches the result, so we don't need to worry about it.
+        $tagarea = core_tag_area::get_areas()[self::ITEM_TYPE]['tool_monitoring'] ?? null;
+        if (is_null($tagarea)) {
+            throw new coding_exception("Could not find the '" . self::ITEM_TYPE . "' tag area");
+        }
+        return $tagarea->tagcollid;
+    }
+
+    /**
+     * Fetches all tags from our collection from the database.
+     *
+     * @return array<string, static> Array of tags indexed by tag name.
+     * @throws coding_exception Tag area for our {@see self::ITEM_TYPE `ITEM_TYPE`} not found.
+     * @throws dml_exception
+     */
+    private static function fetch_all(): array {
+        global $DB;
+        return array_map(
+            callback: fn (stdClass $record): self => new static($record),
+            array:    $DB->get_records('tag', ['tagcollid' => static::get_collection_id()], fields: self::DB_TABLE_FIELDS)
+        );
+    }
+
+    /**
+     * Returns all tags with the given names.
+     *
+     * Attempts to get them from the cache first and only queries the DB if names were not found in the cache.
+     *
+     * **NOTE**: This function does explicit `null`-caching for those names that are not in the DB. This means if a name was not
+     * found in the DB, that fact will be cached. Subsequent calls with the same name will no longer check the DB until that cache
+     * entry is removed.
+     *
+     * @param string ...$names Names of tags to fetch. Will be normalized before looking up the tags.
+     * @return array<string, static> Instances with matching names, indexed by their normalized names.
+     * @throws coding_exception Tag area for our {@see self::ITEM_TYPE `ITEM_TYPE`} not found.
+     * @throws dml_exception
+     * @throws tag_not_found At least one of the provided `$names` does not match any existing metric tag.
+     */
+    public static function get_all_with_names(string ...$names): array {
+        if (empty($names)) {
+            return [];
+        }
+        $names = parent::normalize($names);
+        $cache = cache::make('tool_monitoring', 'metric_tags');
+        $tags = array_filter($cache->get_many($names));
+        $missingtags = array_diff_key(array_fill_keys($names, null), $tags);
+        if ($missingtags) {
+            // Cache miss for at least one name. Fetch all tags and cache them.
+            // Do explicit `null`-caching for those names that are not in the DB to avoid querying it again.
+            $alltags = static::fetch_all();
+            $cache->set_many(array_merge($missingtags, $alltags));
+            // Go through all previously missing tags and add those from the DB to the `$tags` array.
+            // If one of them is still missing, throw an exception.
+            foreach (array_keys($missingtags) as $name) {
+                if (!array_key_exists($name, $alltags)) {
+                    throw new tag_not_found($name, self::COLLECTION_NAME);
+                }
+                $tags[$name] = $alltags[$name];
+            }
+        }
+        return $tags;
+    }
+
+    /**
+     * Returns the tags associated with the metrics with the given IDs.
+     *
+     * @param int ...$ids Registered metric IDs to get the tags for.
+     * @return array<array<string, static>> Array where the keys are the metric IDs and the values are associative arrays of tags
+     *                                      mapped to their normalized names. If tags are disabled, the inner arrays will be empty.
+     */
+    public static function get_for_metric_ids(int ...$ids): array {
+        $arrays = parent::get_items_tags('tool_monitoring', self::ITEM_TYPE, $ids);
+        // Reindex the nested arrays by name.
+        array_walk($arrays, fn (array &$array, int|string $id) => $array = array_column($array, null, 'name'));
+        // If tags are disabled, the `parent::get_items_tags` method just returns an empty array.
+        // We want to ensure the output is always an array indexed by the provided IDs, even if the inner arrays are empty.
+        return $arrays + array_fill_keys($ids, []);
+    }
+
+    /**
+     * Sets tags for the given metric.
+     *
+     * Only actually performs DB queries if tags were either added, removed, or their order changed.
+     *
+     * @param int|registered_metric $metric Either the ID of the metric or the metric instance.
+     * @param string ...$tagnames Names of tags to set.
+     * @throws coding_exception
+     * @throws dml_exception
+     */
+    public static function set_for_metric(int|registered_metric $metric, string ...$tagnames): void {
+        if ($metric instanceof registered_metric) {
+            $metric = $metric->id;
+        }
+        parent::set_item_tags(
+            component: 'tool_monitoring',
+            itemtype: self::ITEM_TYPE,
+            itemid: $metric,
+            context: context_system::instance(),
+            tagnames: $tagnames,
+        );
+    }
+
+    /**
+     * Removes all tags from the given metric.
+     *
+     * @param int|registered_metric $metric Either the ID of the metric or the metric instance.
+     * @throws dml_exception
+     */
+    public static function remove_all_for_metric(int|registered_metric $metric): void {
+        if ($metric instanceof registered_metric) {
+            $metric = $metric->id;
+        }
+        parent::remove_all_item_tags(
+            component: 'tool_monitoring',
+            itemtype: self::ITEM_TYPE,
+            itemid: $metric,
+        );
+    }
+
+    /**
+     * Returns the URL to edit the tag.
+     *
+     * @return moodle_url URL to the tag editing page.
+     * @throws moodle_exception
+     */
+    public function get_edit_url(): moodle_url {
+        return new moodle_url('/tag/edit.php', ['id' => $this->id]);
+    }
+
+    /**
+     * Returns the URL to the tag management page.
+     *
+     * @return moodle_url URL to the tag management page.
+     * @throws moodle_exception
+     */
+    public static function get_manage_url(): moodle_url {
+        return new moodle_url('/tag/manage.php', ['tc' => self::get_collection_id()]);
+    }
+
+    /**
+     * Convenience override for the {@see core_tag_tag::is_enabled} method.
+     *
+     * @param string|null $component Name of the component responsible for tagging; `null` (default) means this plugin.
+     * @param string|null $itemtype Name of the item type; `null` (default) means {@see self::ITEM_TYPE `ITEM_TYPE`}.
+     * @return bool Whether tags in general **and** our tag area in particular are enabled.
+     */
+    #[\Override]
+    public static function is_enabled($component = null, $itemtype = null): bool {
+        return parent::is_enabled($component ?? 'tool_monitoring', $itemtype ?? self::ITEM_TYPE);
+    }
+
+    #[\Override]
+    public function prepare_to_cache(): array {
+        return array_map(fn (string $field) => $this->$field ?? null, self::CACHE_FIELDS);
+    }
+
+    /**
+     * Constructs a new instance from data stored in the cache.
+     *
+     * @param array<string, mixed>|stdClass $data Data to use for construction.
+     * @return self New instance.
+     * @throws coding_exception Data has an unexpected type or is missing required fields.
+     */
+    #[\Override]
+    public static function wake_from_cache(mixed $data): self {
+        if ($data instanceof stdClass) {
+            $data = (array) $data;
+        } else if (!is_array($data) || array_is_list($data)) {
+            throw new coding_exception('Received unexpected data type for metric_tag from cache: ' . gettype($data));
+        }
+        $missing = array_diff_key(self::CACHE_FIELDS, $data);
+        if (!empty($missing)) {
+            throw new coding_exception("Missing cache fields for metric_tag {$data['id']}: " . implode(', ', $missing));
+        }
+        $extra = array_diff_key($data, self::CACHE_FIELDS);
+        if (!empty($extra)) {
+            debugging("Unexpected cache fields for metric_tag {$data['id']}:" . implode(', ', $extra), DEBUG_DEVELOPER);
+        }
+        $data['tagcollid'] = static::get_collection_id();
+        return new static((object) $data);
+    }
+}

--- a/classes/metric_tag.php
+++ b/classes/metric_tag.php
@@ -129,8 +129,19 @@ class metric_tag extends core_tag_tag implements cacheable_object_interface {
         }
         $names = parent::normalize($names);
         $cache = cache::make('tool_monitoring', 'metric_tags');
-        $tags = array_filter($cache->get_many($names));
-        $missingtags = array_diff_key(array_fill_keys($names, null), $tags);
+        [$tags, $missingtags] = [[], []];
+        foreach ($cache->get_many($names) as $name => $tag) {
+            if (is_null($tag)) {
+                // Null-cache hit; no need to query the DB.
+                throw new tag_not_found($name, self::COLLECTION_NAME);
+            } else if ($tag === false) {
+                // Actual cache miss; prepare for null-caching.
+                $missingtags[$name] = null;
+            } else {
+                // Actual cache hit; all good.
+                $tags[$name] = $tag;
+            }
+        }
         if ($missingtags) {
             // Cache miss for at least one name. Fetch all tags and cache them.
             // Do explicit `null`-caching for those names that are not in the DB to avoid querying it again.

--- a/classes/metrics_manager.php
+++ b/classes/metrics_manager.php
@@ -29,24 +29,47 @@
 
 namespace tool_monitoring;
 
+use ArrayAccess;
 use core\di;
 use core\exception\coding_exception;
-use core\hook\manager as hook_manager;
-use core_tag_tag;
+use core_cache\data_source_interface as cache_data_source_interface;
+use core_cache\definition as cache_definition;
 use dml_exception;
 use Exception;
+use JsonException;
+use tool_monitoring\exceptions\metric_not_found;
 use tool_monitoring\exceptions\tag_not_found;
 use tool_monitoring\hook\metric_collection;
+use tool_monitoring\local\metrics_cache;
 
 /**
- * Linchpin of the monitoring API.
+ * Linchpin of the monitoring API and container for all registered metrics.
  *
- * Registers new {@see metric}s picked up by the {@see metric_collection} hook and provides access to already registered ones.
+ * Registers new {@see metric}s picked up by the {@see metric_collection} hook and provides access to registered ones.
  *
- * @property-read array<string, registered_metric> $metrics Registered metrics indexed by their qualified name; must be populated
- *                                                          by calling the {@see self::dispatch_hook} method.
- * @property-read core_tag_tag[] $tags Tags used to filter the metrics. This attribute is only used if this feature is
- *                                     enabled in {@see fetch}.
+ * Provides array-like subscript access to {@see registered_metric} instances by their qualified name.
+ * (See the {@see self::offsetExists `offsetExists`} and {@see self::offsetGet `offsetGet`} methods.)
+ * **NOTE**: Access is read-only. Metrics cannot be added to or removed from the manager directly.
+ *
+ * ```
+ * $manager = di::get(metrics_manager::class);
+ * if (isset($manager['my_metric']) { // This works.
+ *     $metric = $manager['my_metric']; // This also works.
+ *     unset($manager['my_metric']); // Error!
+ * }
+ * $manager['my_metric'] = $something; // Error!
+ * ```
+ *
+ * Collected and registered metrics can be retrieved via the {@see self::filter `filter`} method.
+ * Omitting any arguments will return all of them.
+ *
+ * ```
+ * $manager = di::get(metrics_manager::class);
+ * // Only get enabled metrics that carry the 'foo' tag:
+ * foreach ($manager->filter(enabled: true, tagnames: ['foo']) as $qname => $metric) {
+ *     // Now `$qname` is a string and `$metric` is a `registered_metric` object.
+ * }
+ * ```
  *
  * @package    tool_monitoring
  * @copyright  2025 MootDACH DevCamp
@@ -57,142 +80,64 @@ use tool_monitoring\hook\metric_collection;
  *             Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
  * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-final class metrics_manager {
-    /** @var array<string, registered_metric> Collected and registered metrics indexed by their qualified name. */
-    private array $metrics = [];
-
-    /** @var core_tag_tag[] Tags used to filter the metrics. */
-    private array $tags = [];
-
+final readonly class metrics_manager implements ArrayAccess, cache_data_source_interface {
     /**
      * Constructor without additional logic.
      *
-     * @param metric_collection $collection Metric collection to manage; defaults to a new empty collection.
+     * In production code, the constructor should likely never be called directly. Instead, use {@see di::get} to retrieve an
+     * instance from Moodle's dependency injection container like so:
+     *
+     * ```
+     * $manager = di::get(metrics_manager::class);
+     * ```
+     *
+     * This way, the manager will always have an already dispatched {@see metric_collection}.
+     *
+     * @param metric_collection $collection Metric collection to manage.
      *
      * @phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace
      */
     public function __construct(
-        /** @var metric_collection Metric collection to manage; defaults to a new empty collection. */
-        public readonly metric_collection $collection = new metric_collection()
+        /** @var metric_collection Metric collection being managed. */
+        public metric_collection $collection
     ) {}
 
     /**
-     * Special-case getter for the full array of registered metrics.
+     * Produces **registered** metrics for the managed metrics collection.
      *
-     * TODO Remove this method in favor of nice property `get`-hooks, once PHP 8.4+ becomes the minimum requirement.
+     * If filters were set via the {@see self::filter `filter`} method, yields only those metrics that match the filter criteria.
      *
-     * @param string $name Name of the property to return.
-     * @return mixed Property value.
-     * @throws coding_exception Invalid property name passed.
-     */
-    public function __get(string $name): mixed {
-        if ($name === 'metrics') {
-            return $this->metrics;
-        } else if ($name === 'tags') {
-            return $this->tags;
-        }
-        throw new coding_exception('Undefined property: ' . self::class . '::$' . $name);
-    }
-
-    /**
-     * Dispatches the managed {@see metric_collection} hook allowing callbacks to add metrics.
+     * Will _not_ produce metrics that are not (yet) registered in the database, even if they were picked up by the
+     * {@see metric_collection} hook. To ensure all collected metrics are registered, call {@see self::sync `sync`} first.
      *
-     * @link https://moodledev.io/docs/apis/core/hooks#hook-emitter Documentation: Hook emitter
+     * Implementation detail: Tries to load {@see registered_metric} instances for all metrics in the collection from the cache
+     * first. Since the {@see metrics_manager} is defined as the cache data source, cache misses will trigger the
+     * {@see self::load_many_for_cache `load_many_for_cache`} method, which will query the database for the missing metrics and also
+     * automatically update the cache afterwards.
+     * Explicit `null`-caching is done, when a metric is not found in the DB. The {@see self::sync `sync`} method must be called
+     * to register a newly collected metric and that method also re-builds the cache.
      *
-     * @return $this Same instance.
-     */
-    public function dispatch_hook(): self {
-        di::get(hook_manager::class)->dispatch($this->collection);
-        return $this;
-    }
-
-    /**
-     * Fetches registered metrics from the database for the managed collection.
-     *
-     * Ignores database entries for previously registered metrics that are _not_ present in the currently managed collection.
-     * Issues a single `SELECT` query; does not perform any `INSERT`/`UPDATE`/`DELETE` queries.
-     *
-     * @param bool $collect If `true` (default), calls the {@see self::dispatch_hook `dispatch_hook`} method first.
-     * @param bool|null $enabled If `true` (default), only enabled metrics are loaded; if `false`, only disabled ones are loaded;
+     * @param bool|null $enabled If `true`, the only enabled metrics will be returned; if `false`, only disabled ones;
      *                           passing `null` (default) disables this filter.
-     * @param string[] $tagnames Only metrics that carry tags with all the provided tag names will be returned.
-     * @return $this Same instance.
+     * @param string[] $tagnames Names of tags to filter by. Only metrics that carry all the specified tags will be returned.
+     *                           Names will be normalized before looking up the tags. An empty array (default) disables this filter.
+     * @return array<string, registered_metric> Registered metrics indexed by their qualified name.
      * @throws coding_exception
      * @throws dml_exception
-     * @throws tag_not_found At least one of the provided `$tagnames` does not exist.
+     * @throws tag_not_found At least one of the provided `$tagnames` does not match any existing metric tag.
      */
-    public function fetch(bool $collect = true, bool|null $enabled = true, array $tagnames = []): self {
-        global $DB;
-        if ($collect) {
-            $this->dispatch_hook();
+    public function filter(bool|null $enabled = null, array $tagnames = []): array {
+        $tags = metric_tag::get_all_with_names(...$tagnames);
+        $qnames = [];
+        foreach ($this->collection as $metric) {
+            $qname = registered_metric::get_qualified_name($metric::get_component(), $metric::get_name());
+            $qnames[$qname] = true;
         }
-        $this->metrics = [];
-        // Store metrics indexed by qualified name for later.
-        $metrics = [];
-        // Construct the `IN` expression and parameters from the component-name-combinations present in the collection.
-        $inplaceholders = [];
-        $params = [];
-        foreach ($this->collection as $i => $metric) {
-            $component = $metric::get_component();
-            $name = $metric::get_name();
-            $qname = registered_metric::get_qualified_name($component, $name);
-            if (array_key_exists($qname, $metrics)) {
-                trigger_error("Collected more than one metric with the qualified name '$qname'", E_USER_WARNING);
-                continue;
-            }
-            $metrics[$qname] = $metric;
-            $inplaceholders[] = "(:component$i,:name$i)";
-            $params["component$i"] = $component;
-            $params["name$i"] = $name;
-        }
-        $where = '(m.component,m.name) IN (' . implode(',', $inplaceholders) . ')';
-        $join = '';
-        // Filter by tags.
-        $tagsenabled = core_tag_tag::is_enabled('tool_monitoring', registered_metric::TABLE);
-        if ($tagsenabled) {
-            if (!empty($tagnames)) {
-                $tagcollid = $DB->get_field('tag_coll', 'id', ['name' => 'monitoring', 'component' => 'tool_monitoring']);
-                $this->tags = core_tag_tag::get_by_name_bulk($tagcollid, $tagnames);
-                if ($badtagname = array_search(null, $this->tags, true)) {
-                    throw new tag_not_found($badtagname, 'monitoring');
-                }
-                $tagids = array_column($this->tags, 'id');
-            }
-            if (!empty($tagids)) {
-                [$insql, $inparams] = $DB->get_in_or_equal($tagids, SQL_PARAMS_NAMED, 'tag');
-                $params += $inparams;
-                $params += [
-                    'tagcomponent' => 'tool_monitoring',
-                    'tagitemtype' => registered_metric::TABLE,
-                    'tagcount' => count($tagids),
-                ];
-                $subselect = "SELECT ti.itemid
-                        FROM {tag_instance} ti
-                       WHERE ti.tagid $insql
-                         AND ti.component = :tagcomponent
-                         AND ti.itemtype  = :tagitemtype
-                    GROUP BY ti.itemid
-                HAVING COUNT(DISTINCT ti.tagid) = :tagcount";
-                $join = "JOIN ($subselect) x ON x.itemid = m.id";
-            }
-        }
-        $tablename = registered_metric::TABLE;
-        $sqlqname = $DB->sql_concat_join(separator: "'_'", elements: ["m.component", "m.name"]);
-        $sql = "SELECT $sqlqname AS qname, m.*
-                  FROM {{$tablename}} m
-                 $join
-                 WHERE $where";
-        // Filter by enabled.
-        if (!is_null($enabled)) {
-            $sql .= ' AND enabled = :enabled';
-            $params['enabled'] = $enabled;
-        }
-        // Issue a single `SELECT` query and construct the instances from the returned records.
-        $records = $DB->get_records_sql($sql, $params);
-        foreach ($records as $qname => $record) {
-            $this->metrics[$qname] = registered_metric::from_metric($metrics[$qname], ...(array) $record);
-        }
-        return $this;
+        return array_filter(
+            metrics_cache::get_many(...array_keys($qnames)),
+            fn (registered_metric|null $metric): bool
+            => !is_null($metric) && (is_null($enabled) || $metric->enabled === $enabled) && !array_diff_key($tags, $metric->tags),
+        );
     }
 
     /**
@@ -201,93 +146,63 @@ final class metrics_manager {
      * Ensures that a corresponding entry in the database exists for every unique metric in the collection (per qualified name).
      * Optionally deletes every database entry that does not correspond to any metric in the collection.
      *
-     * This function issues no more than two `SELECT`, exactly one `DELETE` (optional), and no more than two `INSERT` queries.
+     * This function issues exactly three `SELECT`, one `DELETE` (optional), and one `INSERT` queries.
      *
-     * @param bool $collect If `true` (default), calls the {@see self::dispatch_hook `dispatch_hook`} method first.
-     *                      **WARNING**: Failing to collect relevant metrics first will cause data loss if `$delete` is `true`.
      * @param bool $delete If `true`, deletes every database entry that does not correspond to any metric in the collection, and
      *                     triggers individual deletion events for all deleted database records.
      * @return $this Same instance.
      * @throws coding_exception
      * @throws dml_exception
+     * @throws JsonException A metric is configurable but it's default config could not be serialized.
      */
-    public function sync(bool $collect = true, bool $delete = false): self {
+    public function sync(bool $delete = false): self {
         global $DB, $USER;
-        if ($collect) {
-            $this->dispatch_hook();
-        }
-        $this->metrics = [];
-        // Grab all existing records indexed by qualified name.
-        $sqlqname = $DB->sql_concat_join(separator: "'_'", elements: ['component', 'name']);
         try {
             $transaction = $DB->start_delegated_transaction();
-            $existingrecords = $DB->get_records_sql("SELECT $sqlqname AS qname, m.* FROM {" . registered_metric::TABLE . "} AS m");
-            // For us to later know which records were inserted, we remember the existing IDs.
-            [$notexistingsql, $notexistingparams] = $DB->get_in_or_equal(
-                items:        array_column($existingrecords, 'id'),
-                equal:        false,
-                onemptyitems: null,
-            );
-            // Iterate over the collection. Construct a new instance for every metric in the collection that has a DB record
-            // and add that instance to the `metrics`, making sure to remove the corresponding item from `$existingrecords`.
-            // Track all metrics _without_ a matching DB record in the `$unregistered` array.
-            $unregistered = [];
-            foreach ($this->collection as $metric) {
-                $qname = registered_metric::get_qualified_name($metric::get_component(), $metric::get_name());
-                if (array_key_exists($qname, $this->metrics)) {
-                    trigger_error("Collected more than one metric with the qualified name '$qname'", E_USER_WARNING);
-                    continue;
-                }
-                if (array_key_exists($qname, $existingrecords)) {
-                    $this->metrics[$qname] = registered_metric::from_metric($metric, ...(array) $existingrecords[$qname]);
-                    unset($existingrecords[$qname]);
-                } else {
-                    $unregistered[$qname] = $metric;
-                    // This is just a placeholder for the duplicate check above to work.
-                    $this->metrics[$qname] = registered_metric::from_metric($metric);
-                }
-            }
-            // At this point `$existingrecords` should only contain "orphans", i.e. entries for metrics not found in the collection,
-            // and `$unregistered` should contain those metrics from the collection that do not have a corresponding DB entry.
-            // Optionally, delete the former and insert the latter.
-            if ($delete) {
-                foreach ($existingrecords as $record) {
-                    core_tag_tag::remove_all_item_tags('tool_monitoring', registered_metric::TABLE, $record->id);
-                }
-                [$oprphansql, $orphanparams] = $DB->get_in_or_equal(array_column($existingrecords, 'id'), onemptyitems: null);
-                $DB->delete_records_select(registered_metric::TABLE, "id $oprphansql", $orphanparams);
-                // TODO: Trigger individual deletion events here.
-            }
+            // Get a `registered_metric` instance for every metric we collected.
+            // Some may have no DB record and thus a `null` ID; those will need to be inserted.
+            $metrics = registered_metric::get_for_metrics(...iterator_to_array($this->collection));
+            // Prepare records for insertion and remember the existing IDs of collected-and-registered metrics.
+            $existingids = [];
             $toinsert = [];
             $currenttime = time();
-            foreach ($unregistered as $qname => $metric) {
-                // Prepare the new instances here, then assign their new IDs after insertion.
-                $instance = registered_metric::from_metric(
-                    metric:       $metric,
-                    timecreated:  $currenttime,
-                    timemodified: $currenttime,
-                    usermodified: $USER->id,
-                );
-                $toinsert[$qname] = (array) $instance;
-                $this->metrics[$qname] = $instance;
+            foreach ($metrics as $qname => $metric) {
+                if (is_null($metric->id)) {
+                    $metric->timecreated = $currenttime;
+                    $metric->timemodified = $currenttime;
+                    $metric->usermodified = $USER->id;
+                    $toinsert[$qname] = $metric->to_db();
+                } else {
+                    $existingids[] = $metric->id;
+                }
             }
-            if (count($unregistered) > 2) {
-                // Insert in bulk, then grab the new IDs.
+            // Insert in bulk.
+            if ($toinsert) {
                 $DB->insert_records(registered_metric::TABLE, $toinsert);
-                $newids = $DB->get_records_select_menu(
-                    table:  registered_metric::TABLE,
-                    select: "id $notexistingsql",
-                    params: $notexistingparams,
-                    fields: "$sqlqname AS qname, id",
-                );
-                foreach ($newids as $qname => $id) {
-                    $this->metrics[$qname]->id = $id;
+            }
+            // Fetch all records that we did not get before.
+            // These should only be newly inserted ones (if any) and orphans (without a collected metric).
+            [$notexistingsql, $notexistingparams] = $DB->get_in_or_equal($existingids, equal: false, onemptyitems: null);
+            $sqlqname = $DB->sql_concat_join(separator: "'_'", elements: ['component', 'name']);
+            $otherids = $DB->get_records_select_menu(
+                table:  registered_metric::TABLE,
+                select: "id $notexistingsql",
+                params: $notexistingparams,
+                fields: "$sqlqname AS qname, id",
+            );
+            // Assign the newly inserted IDs and remove them from the array.
+            foreach (array_keys($toinsert) as $qname) {
+                $metrics[$qname]->id = $otherids[$qname];
+                unset($otherids[$qname]);
+            }
+            // At this point `$otherids` should only contain orphan IDs.
+            if ($delete) {
+                foreach ($otherids as $id) {
+                    metric_tag::remove_all_for_metric($id);
                 }
-            } else {
-                // Insert individually.
-                foreach ($toinsert as $qname => $data) {
-                    $this->metrics[$qname]->id = $DB->insert_record(registered_metric::TABLE, $data);
-                }
+                [$oprphansql, $orphanparams] = $DB->get_in_or_equal($otherids, onemptyitems: null);
+                $DB->delete_records_select(registered_metric::TABLE, "id $oprphansql", $orphanparams);
+                // TODO: Trigger individual deletion events here.
             }
             $transaction->allow_commit();
             // @codeCoverageIgnoreStart
@@ -298,6 +213,132 @@ final class metrics_manager {
             throw $e;
         }
         // @codeCoverageIgnoreEnd
+        metrics_cache::purge();
+        metrics_cache::set(...$metrics);
         return $this;
+    }
+
+    /**
+     * Checks whether a metric with the given qualified name is registered.
+     *
+     * Will return `false` if no metric with the given qualified name is (yet) registered in the database, even one was picked up by
+     * the {@see metric_collection} hook. To ensure all collected metrics are registered, call {@see self::sync `sync`} first.
+     *
+     * @param string $offset Qualified name of the metric to check.
+     * @return bool `true` if the metric is registered, `false` otherwise.
+     * @throws coding_exception
+     */
+    #[\Override]
+    public function offsetExists(mixed $offset): bool {
+        try {
+            $this->offsetGet($offset);
+            return true;
+        } catch (metric_not_found) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the registered metric with the given qualified name.
+     *
+     * Will _not_ return a metric not (yet) registered in the database, even if it was picked up by the {@see metric_collection}
+     * hook. To ensure all collected metrics are registered, call {@see self::sync `sync`} first.
+     *
+     * Implementation detail: Tries to load the requested {@see registered_metric} instance from the cache first.
+     * Since the {@see metrics_manager} is defined as the cache data source, a cache miss will trigger the
+     * {@see self::load_for_cache `load_for_cache`} method, which will query the database for the missing metric and also
+     * automatically update the cache afterwards.
+     *
+     * @param string $offset Qualified name of the metric to return.
+     * @return registered_metric Metric with the given qualified name.
+     * @throws coding_exception
+     * @throws metric_not_found No metric with the given qualified name is registered.
+     */
+    #[\Override]
+    public function offsetGet(mixed $offset): registered_metric {
+        if (is_null($metric = metrics_cache::get($offset))) {
+            throw new metric_not_found($offset);
+        }
+        return $metric;
+    }
+
+    /**
+     * Always throws an exception because the managed metrics are read-only.
+     *
+     * @param mixed $offset Ignored
+     * @param mixed $value Ignored
+     * @throws coding_exception
+     */
+    #[\Override]
+    public function offsetSet(mixed $offset, mixed $value): void {
+        throw new coding_exception('Cannot manually set metrics.');
+    }
+
+    /**
+     * Always throws an exception because the managed metrics are read-only.
+     *
+     * @param mixed $offset Ignored
+     * @throws coding_exception
+     */
+    #[\Override]
+    public function offsetUnset(mixed $offset): void {
+        throw new coding_exception('Cannot manually unset metrics.');
+    }
+
+    /**
+     * Required for the {@see cache_data_source_interface `core_cache\data_source_interface`}.
+     *
+     * @param cache_definition $definition Cache definition object.
+     * @return self Instance of the class.
+     */
+    #[\Override]
+    public static function get_instance_for_cache(cache_definition $definition): self {
+        return di::get(self::class);
+    }
+
+    /**
+     * Fetches a {@see registered_metric} instance with the given qualified name from the DB.
+     *
+     * Implementation detail: This method facilitates null-caching if the key either does not match any collected metric or refers
+     * to a metric that has not (yet) been registered in the database.
+     *
+     * @param string $key Qualified name of the metric to fetch.
+     * @return registered_metric|null Metric instance or `null` if no matching metric was not found in the DB.
+     * @throws dml_exception
+     * @throws JsonException A metric is configurable but it's default config could not be serialized.
+     */
+    #[\Override]
+    public function load_for_cache($key): registered_metric|null {
+        $metrics = $this->load_many_for_cache([$key]);
+        return $metrics[$key];
+    }
+
+    /**
+     * Fetches {@see registered_metric} instances with the given qualified names from the DB.
+     *
+     * Implementation detail: This method facilitates null-caching for keys that either do not match any collected metric and those
+     * that refer to metrics that have not (yet) been registered in the database.
+     *
+     * @param string[] $keys Qualified names of the metrics to fetch.
+     * @return array<string, registered_metric|null> Associative array indexed with `$keys` mapped to {@see registered_metric}
+     *                                               instances or `null` if no matching metric was not found in the DB.
+     * @throws dml_exception
+     * @throws JsonException A metric is configurable but it's default config could not be serialized.
+     */
+    #[\Override]
+    public function load_many_for_cache(array $keys): array {
+        $output = array_fill_keys($keys, null);
+        $metrics = [];
+        foreach ($this->collection as $metric) {
+            $qname = registered_metric::get_qualified_name($metric::get_component(), $metric::get_name());
+            if (array_key_exists($qname, $output)) {
+                $metrics[$qname] = $metric;
+            }
+        }
+        $registeredmetrics = array_filter(
+            array:    registered_metric::get_for_metrics(...$metrics), // The function discards variadic argument names.
+            callback: fn (registered_metric $metric): bool => !is_null($metric->id),
+        );
+        return array_merge($output, $registeredmetrics);
     }
 }

--- a/classes/metrics_manager.php
+++ b/classes/metrics_manager.php
@@ -127,6 +127,9 @@ final readonly class metrics_manager implements ArrayAccess, cache_data_source_i
      * @throws tag_not_found At least one of the provided `$tagnames` does not match any existing metric tag.
      */
     public function filter(bool|null $enabled = null, array $tagnames = []): array {
+        if ($tagnames && !metric_tag::is_enabled()) {
+            throw new tag_not_found(reset($tagnames), metric_tag::COLLECTION_NAME);
+        }
         $tags = metric_tag::get_all_with_names(...$tagnames);
         $qnames = [];
         foreach ($this->collection as $metric) {

--- a/classes/metrics_manager.php
+++ b/classes/metrics_manager.php
@@ -130,13 +130,14 @@ final readonly class metrics_manager implements ArrayAccess, cache_data_source_i
         $tags = metric_tag::get_all_with_names(...$tagnames);
         $qnames = [];
         foreach ($this->collection as $metric) {
-            $qname = registered_metric::get_qualified_name($metric::get_component(), $metric::get_name());
-            $qnames[$qname] = true;
+            $qnames[] = registered_metric::get_qualified_name($metric::get_component(), $metric::get_name());
         }
         return array_filter(
-            metrics_cache::get_many(...array_keys($qnames)),
-            fn (registered_metric|null $metric): bool
-            => !is_null($metric) && (is_null($enabled) || $metric->enabled === $enabled) && !array_diff_key($tags, $metric->tags),
+            metrics_cache::get_many(...$qnames),
+            fn (registered_metric|null $cachedmetric): bool
+            => !is_null($cachedmetric)
+               && (is_null($enabled) || $cachedmetric->enabled === $enabled)
+               && !array_diff_key($tags, $cachedmetric->tags),
         );
     }
 
@@ -337,7 +338,7 @@ final readonly class metrics_manager implements ArrayAccess, cache_data_source_i
         }
         $registeredmetrics = array_filter(
             array:    registered_metric::get_for_metrics(...$metrics), // The function discards variadic argument names.
-            callback: fn (registered_metric $metric): bool => !is_null($metric->id),
+            callback: fn (registered_metric $registeredmetric): bool => !is_null($registeredmetric->id),
         );
         return array_merge($output, $registeredmetrics);
     }

--- a/classes/output/overview.php
+++ b/classes/output/overview.php
@@ -34,8 +34,8 @@ use core\output\renderable;
 use core\output\renderer_base;
 use core\output\templatable;
 use moodle_url;
+use tool_monitoring\metric_tag;
 use tool_monitoring\registered_metric;
-use core_tag_tag;
 
 /**
  * Provides information about all available metrics and links to their configuration pages.
@@ -53,26 +53,26 @@ final readonly class overview implements renderable, templatable {
     /**
      * Constructor without additional logic.
      *
-     * @param array<string, registered_metric> $metrics Metrics for which to render the overview, indexed by qualified name.
-     * @param array<core_tag_tag> $tags Metrics were filtered with these tags.
+     * @param iterable<string, registered_metric> $metrics Metrics for which to render the overview, indexed by qualified name.
+     * @param array<string, metric_tag> $tags Tags used to filter the metrics by, indexed by normalized tag name.
      *
      * @phpcs:disable Squiz.WhiteSpace.ScopeClosingBrace
      */
     public function __construct(
-        /** @var array<string, registered_metric> Metrics for which to render the overview, indexed by qualified name. */
-        private array $metrics,
-        /** @var array<string, core_tag_tag> Metrics were filtered with these tags, indexed by normalized tag name. */
+        /** @var iterable<string, registered_metric> Metrics for which to render the overview, indexed by qualified name. */
+        private iterable $metrics,
+        /** @var array<string, metric_tag> Tags used to filter the metrics by, indexed by normalized tag name. */
         private array $tags
     ) {}
 
     /**
      * Generates a URL to the current overview with an additional tag in the filter.
      *
-     * @param core_tag_tag $tag New tag.
+     * @param metric_tag $tag New tag.
      * @return moodle_url URL with the `tag` query parameter listing the current {@see self::$tags} and the new `$tag`.
      * @throws moodle_exception
      */
-    private function add_tag_url(core_tag_tag $tag): moodle_url {
+    private function add_tag_url(metric_tag $tag): moodle_url {
         $tags = $this->tags;
         if (!array_key_exists($tag->name, $tags)) {
             $tags[$tag->name] = $tag;
@@ -83,11 +83,11 @@ final readonly class overview implements renderable, templatable {
     /**
      * Generates a URL to the current overview with one tag removed from the filter.
      *
-     * @param core_tag_tag $tag Tag to remove.
+     * @param metric_tag $tag Tag to remove.
      * @return moodle_url URL with the `tag` query parameter listing the current {@see self::$tags} minus the `$tag`.
      * @throws moodle_exception
      */
-    private function remove_tag_url(core_tag_tag $tag): moodle_url {
+    private function remove_tag_url(metric_tag $tag): moodle_url {
         $tags = $this->tags;
         unset($tags[$tag->name]);
         $params = [];
@@ -106,10 +106,7 @@ final readonly class overview implements renderable, templatable {
      */
     #[\Override]
     public function export_for_template(renderer_base $output): array {
-        global $DB;
-        $tagcollid = $DB->get_field('tag_coll', 'id', ['name' => 'monitoring', 'component' => 'tool_monitoring']);
-        $tagsenabled = core_tag_tag::is_enabled('tool_monitoring', registered_metric::TABLE);
-        $managetagsurl = new moodle_url('/tag/manage.php', ['tc' => $tagcollid]);
+        $tagsenabled = metric_tag::is_enabled();
         $lines = [];
         foreach ($this->metrics as $qualifiedname => $metric) {
             $configurl = new moodle_url('/admin/tool/monitoring/configure.php', ['metric' => $qualifiedname]);
@@ -123,14 +120,13 @@ final readonly class overview implements renderable, templatable {
                 'config_url' => $configurl->out(escaped: false),
             ];
             if ($tagsenabled) {
-                $tags = core_tag_tag::get_item_tags('tool_monitoring', registered_metric::TABLE, $metric->id);
                 $line['tags'] = array_map(
-                    fn (core_tag_tag $tag): array => [
+                    fn (metric_tag $tag): array => [
                         'id' => $tag->id,
                         'name' => $tag->rawname,
                         'view_url' => $this->add_tag_url($tag)->out(escaped: false),
                     ],
-                    array_values($tags),
+                    array_values($metric->tags),
                 );
             }
             $lines[] = $line;
@@ -139,7 +135,7 @@ final readonly class overview implements renderable, templatable {
         $data = [
             'metrics' => $lines,
             'is_tagging_enabled' => $tagsenabled,
-            'manage_tags_url' => $managetagsurl,
+            'manage_tags_url' => metric_tag::get_manage_url(),
             'has_tags' => $hastags,
         ];
         if ($hastags) {
@@ -147,11 +143,10 @@ final readonly class overview implements renderable, templatable {
             $data['all_metrics_url'] = $allmetricsurl->out(escaped: false);
             $data['tags'] = [];
             foreach ($this->tags as $tag) {
-                $editurl = new moodle_url('/tag/edit.php', ['id' => $tag->id]);
                 $data['tags'][] = [
                     'name' => $tag->rawname,
                     'remove_url' => $this->remove_tag_url($tag)->out(escaped: false),
-                    'edit_url' => $editurl->out(escaped: false),
+                    'edit_url' => $tag->get_edit_url()->out(escaped: false),
                 ];
             }
         }

--- a/classes/registered_metric.php
+++ b/classes/registered_metric.php
@@ -29,16 +29,16 @@
 
 namespace tool_monitoring;
 
-use context_system;
 use core\exception\coding_exception;
 use core\lang_string;
-use core_tag_tag;
+use core_cache\cacheable_object_interface;
 use dml_exception;
 use IteratorAggregate;
 use JsonException;
 use moodleform;
 use stdClass;
 use tool_monitoring\form\config as config_form;
+use tool_monitoring\local\metrics_cache;
 use Traversable;
 
 /**
@@ -51,6 +51,7 @@ use Traversable;
  * @property-read lang_string $description Localized description of the metric.
  * @property-read metric_type $type Type of the metric.
  * @property-read class-string<metric_config>|null $configclass Name of the associated metric config class, if any.
+ * @property-read array<string, metric_tag> $tags Tags on the metric, indexed by their normalized name.
  *
  * @package    tool_monitoring
  * @copyright  2025 MootDACH DevCamp
@@ -61,7 +62,7 @@ use Traversable;
  *             Melanie Treitinger <melanie.treitinger@ruhr-uni-bochum.de>
  * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-final class registered_metric implements IteratorAggregate {
+final class registered_metric implements cacheable_object_interface, IteratorAggregate {
     /** @var string Name of the mapped DB table. */
     public const TABLE = 'tool_monitoring_metrics';
 
@@ -77,11 +78,29 @@ final class registered_metric implements IteratorAggregate {
         'id',
     ];
 
+    /** @var array<string, string> Properties of interest that are cached; for convenience, keys and values are the same. */
+    private const CACHE_FIELDS = [
+        'id' => 'id',
+        'component' => 'component',
+        'name' => 'name',
+        'enabled' => 'enabled',
+        'config' => 'config',
+        'timecreated' => 'timecreated',
+        'timemodified' => 'timemodified',
+        'usermodified' => 'usermodified',
+        'metric' => 'metric',
+        'configclass' => 'configclass',
+        'tags' => 'tags',
+    ];
+
     /** @var metric Underlying metric that the instance wraps. */
     private metric $metric;
 
     /** @var class-string<metric_config>|null Name of the associated metric config class; `null` if not configurable. */
     private string|null $configclass = null;
+
+    /** @var array<string, metric_tag> Tags on the metric, indexed by their normalized name. */
+    private array $tags = [];
 
     /**
      * Constructor without additional logic.
@@ -119,35 +138,93 @@ final class registered_metric implements IteratorAggregate {
     /**
      * Constructs a new instance from the specified metric.
      *
-     * @param metric $metric Metric to wrap in the new instance; unless passed via `...$properties`, the `component`, `name`,
-     *                       and `config` properties are derived from the {@see metric::get_component}, {@see metric::get_name},
-     *                       and {@see metric::get_default_config} methods respectively.
-     * @param mixed ...$properties Properties to set/overwrite on the new instance; non-property names are ignored.
-     * @return self New instance from the provided metric and optional properties.
+     * @param metric $metric Metric to wrap in the new instance; the {@see self::$component `component`}, {@see self::$name `name`},
+     *                       {@see self::$configclass `configclass`}, and {@see self::$config `config`} properties are derived from
+     *                       {@see metric::get_component}, {@see metric::get_name}, and {@see metric::get_default_config}.
+     * @return self New instance from the provided metric.
+     * @throws JsonException The metric is configurable but it's default config could not be serialized.
      */
-    public static function from_metric(metric $metric, mixed ...$properties): self {
-        $arguments = [
-            'component' => $metric::get_component(),
-            'name'      => $metric::get_name(),
-        ];
-        foreach (self::FIELDS as $name) {
-            if (!array_key_exists($name, $properties)) {
+    public static function from_metric(metric $metric): self {
+        $instance = new self(component: $metric::get_component(), name: $metric::get_name());
+        $instance->set_metric($metric);
+        return $instance;
+    }
+
+    /**
+     * Constructs new instances from the provided metrics, querying the DB for corresponding records.
+     *
+     * The returned array is indexed by the qualified names of the provided metrics. If a metric is not found in the database,
+     * the corresponding instance will only have its {@see self::$component `component`} and {@see self::$name `name`} set, as well
+     * as its {@see self::$config `config`} and {@see self::$configclass `configclass`}, if the metric is configurable.
+     *
+     * @param metric ...$metrics Metrics to construct new instances from.
+     *                           Their qualified names **should** be unique, otherwise a warning will be emitted.
+     * @return array<string, self> Associative array of instances, indexed by the qualified names of the provided metrics.
+     * @throws dml_exception
+     * @throws JsonException A metric is configurable but it's default config could not be serialized.
+     */
+    public static function get_for_metrics(metric ...$metrics): array {
+        global $DB;
+        if (empty($metrics)) {
+            return [];
+        }
+        $results = [];
+        // Construct the `IN` expression and parameters from all unique component-name-combinations.
+        $inplaceholders = [];
+        $params = [];
+        foreach (array_values($metrics) as $i => $metric) {
+            // Create the instance now and store it in the `$results` array.
+            // If we find a matching record later, we will update that instance.
+            $instance = self::from_metric($metric);
+            $qname = $instance->qualifiedname;
+            if (array_key_exists($qname, $results)) {
+                trigger_error("More than one metric with the qualified name '$qname'", E_USER_WARNING);
                 continue;
             }
-            $arguments[$name] = $properties[$name];
+            $results[$qname] = $instance;
+            $inplaceholders[] = "(:component$i, :name$i)";
+            $params["component$i"] = $instance->component;
+            $params["name$i"] = $instance->name;
         }
-        $instance = new self(...$arguments);
+        $inlist = implode(', ', $inplaceholders);
+        $sqlqname = $DB->sql_concat_join(separator: "'_'", elements: ['component', 'name']);
+        $records = $DB->get_records_select(
+            table:  self::TABLE,
+            select: "(component, name) IN ($inlist)",
+            params: $params,
+            fields: "$sqlqname AS qname, *"
+        );
+        $tags = metric_tag::get_for_metric_ids(...array_column($records, 'id'));
+        foreach ($records as $qname => $record) {
+            $instance = $results[$qname];
+            foreach (self::FIELDS as $name) {
+                $instance->$name = $record->$name;
+            }
+            $instance->tags = $tags[$record->id] ?? []; // Tags may be disabled.
+        }
+        return $results;
+    }
+
+    /**
+     * Assigns the provided metric to the instance.
+     *
+     * If the metric is configurable, sets the instance's {@see self::$configclass `configclass`} and {@see self::config `config`}
+     * properties consistently and updates the metric's {@see metric_with_config::$configjson `configjson`} property.
+     *
+     * @param metric $metric Metric to assign to the instance.
+     * @throws JsonException No {@see self::config `config`} was set and the default config could not be serialized.
+     */
+    private function set_metric(metric $metric): void {
         if ($metric instanceof metric_with_config) {
             $defaultconfig = $metric::get_default_config();
-            $instance->configclass = $defaultconfig::class;
-            if (!array_key_exists('config', $arguments)) {
-                // No config was passed to the constructor; fall back to the default.
-                $instance->config = json_encode($defaultconfig);
+            $this->configclass = $defaultconfig::class;
+            if (is_null($this->config)) {
+                // No config set yet; fall back to the default.
+                $this->config = json_encode($defaultconfig, JSON_THROW_ON_ERROR);
             }
-            $metric->configjson = $instance->config;
+            $metric->configjson = $this->config;
         }
-        $instance->metric = $metric;
-        return $instance;
+        $this->metric = $metric;
     }
 
     /**
@@ -161,7 +238,7 @@ final class registered_metric implements IteratorAggregate {
      *                              properties will be included in the output array.
      * @return array<string, mixed> DB-friendly data taken from the instance.
      */
-    private function to_db(array|null $fields = null): array {
+    public function to_db(array|null $fields = null): array {
         $data = [];
         if (!is_null($this->id)) {
             $data['id'] = $this->id;
@@ -182,6 +259,7 @@ final class registered_metric implements IteratorAggregate {
      * The {@see timemodified} and {@see usermodified} are set to the current time and user respectively before the update.
      *
      * @param string[]|null $fields If specified, only these fields will be updated.
+     * @throws coding_exception
      * @throws dml_exception
      */
     private function update(array|null $fields = null): void {
@@ -189,6 +267,7 @@ final class registered_metric implements IteratorAggregate {
         $this->timemodified = time();
         $this->usermodified = $USER->id;
         $DB->update_record(self::TABLE, $this->to_db($fields));
+        metrics_cache::set($this);
     }
 
     /**
@@ -239,7 +318,24 @@ final class registered_metric implements IteratorAggregate {
             'description'   => $this->metric::get_description(),
             'type'          => $this->metric::get_type(),
             'configclass'   => $this->configclass,
+            'tags'          => $this->tags,
             default         => throw new coding_exception('Undefined property: ' . self::class . '::$' . $name),
+        };
+    }
+
+    /**
+     * Special-case {@see isset} check for some public-read-only properties of the metric.
+     *
+     * TODO Remove this method in favor of nice property `get`-hooks, once PHP 8.4+ becomes the minimum requirement.
+     *
+     * @param string $name Name of the property to check.
+     * @return bool `true` if the property is set, `false` otherwise.
+     */
+    public function __isset(string $name): bool {
+        return match ($name) {
+            'configclass', 'description', 'qualifiedname', 'type' => isset($this->metric),
+            'tags' => isset($this->tags),
+            default => false,
         };
     }
 
@@ -255,7 +351,11 @@ final class registered_metric implements IteratorAggregate {
             $formdata = [];
         }
         $formdata['enabled'] = $this->enabled;
-        $formdata['tags'] = core_tag_tag::get_item_tags_array('tool_monitoring', self::TABLE, $this->id);
+        $tags = [];
+        foreach ($this->tags as $tag) {
+            $tags[$tag->id] = $tag->get_display_name();
+        }
+        $formdata['tags'] = $tags;
         return $formdata;
     }
 
@@ -289,14 +389,7 @@ final class registered_metric implements IteratorAggregate {
                 $events[] = event\metric_config_updated::for_metric($this);
             }
         }
-        // This only actually performs DB queries if tags were either added, removed, or their order changed.
-        core_tag_tag::set_item_tags(
-            component: 'tool_monitoring',
-            itemtype: self::TABLE,
-            itemid: $this->id,
-            context: context_system::instance(),
-            tagnames: $formdata->tags
-        );
+        metric_tag::set_for_metric($this, ...$formdata->tags);
         if (empty($events)) {
             return;
         }
@@ -323,5 +416,48 @@ final class registered_metric implements IteratorAggregate {
         } else {
             yield from $values;
         }
+    }
+
+    #[\Override]
+    public function prepare_to_cache(): array {
+        $data = [];
+        foreach (self::CACHE_FIELDS as $field) {
+            $data[$field] = match ($field) {
+                'tags' => array_map(fn (metric_tag $tag): array => $tag->prepare_to_cache(), $this->tags),
+                'metric' => get_class($this->metric), // Store just the class name.
+                default => $this->$field,
+            };
+        }
+        return $data;
+    }
+
+    /**
+     * Constructs a new instance from data stored in the cache.
+     *
+     * @param array<string, mixed>|stdClass $data Data to use for construction.
+     * @return self New instance.
+     * @throws coding_exception Data has an unexpected type or is missing required fields.
+     * @throws JsonException Should never happen.
+     */
+    #[\Override]
+    public static function wake_from_cache(mixed $data): self {
+        if ($data instanceof stdClass) {
+            $data = (array) $data;
+        } else if (!is_array($data) || array_is_list($data)) {
+            throw new coding_exception('Received unexpected data type for registered_metric from cache: ' . gettype($data));
+        }
+        $missing = array_diff_key(self::CACHE_FIELDS, $data);
+        if (!empty($missing)) {
+            throw new coding_exception("Missing cache fields for registered_metric {$data['id']}: " . implode(', ', $missing));
+        }
+        $extra = array_diff_key($data, self::CACHE_FIELDS);
+        if (!empty($extra)) {
+            debugging("Unexpected cache fields for registered_metric {$data['id']}:" . implode(', ', $extra), DEBUG_DEVELOPER);
+        }
+        $instance = new self(...array_intersect_key($data, array_flip(self::FIELDS)));
+        $metric = new $data['metric'](); // Construct from the class name.
+        $instance->set_metric($metric);
+        $instance->tags = array_map(fn (array $tag): metric_tag => metric_tag::wake_from_cache($tag), $data['tags']);
+        return $instance;
     }
 }

--- a/classes/registered_metric.php
+++ b/classes/registered_metric.php
@@ -188,12 +188,11 @@ final class registered_metric implements cacheable_object_interface, IteratorAgg
         }
         $inlist = implode(', ', $inplaceholders);
         $sqlqname = $DB->sql_concat_join(separator: "'_'", elements: ['component', 'name']);
-        $records = $DB->get_records_select(
-            table:  self::TABLE,
-            select: "(component, name) IN ($inlist)",
-            params: $params,
-            fields: "$sqlqname AS qname, *"
-        );
+        $tablename = self::TABLE;
+        $sql = "SELECT $sqlqname, m.*
+                  FROM {{$tablename}} AS m
+                 WHERE (m.component, m.name) IN ($inlist)";
+        $records = $DB->get_records_sql($sql, $params);
         $tags = metric_tag::get_for_metric_ids(...array_column($records, 'id'));
         foreach ($records as $qname => $record) {
             $instance = $results[$qname];

--- a/classes/registered_metric.php
+++ b/classes/registered_metric.php
@@ -267,7 +267,7 @@ final class registered_metric implements cacheable_object_interface, IteratorAgg
         $this->timemodified = time();
         $this->usermodified = $USER->id;
         $DB->update_record(self::TABLE, $this->to_db($fields));
-        metrics_cache::set($this);
+        metrics_cache::delete($this->qualifiedname);
     }
 
     /**

--- a/classes/registered_metric.php
+++ b/classes/registered_metric.php
@@ -29,6 +29,7 @@
 
 namespace tool_monitoring;
 
+use core\di;
 use core\exception\coding_exception;
 use core\lang_string;
 use core_cache\cacheable_object_interface;
@@ -38,6 +39,7 @@ use JsonException;
 use moodleform;
 use stdClass;
 use tool_monitoring\form\config as config_form;
+use tool_monitoring\hook\metric_collection;
 use tool_monitoring\local\metrics_cache;
 use Traversable;
 
@@ -88,7 +90,6 @@ final class registered_metric implements cacheable_object_interface, IteratorAgg
         'timecreated' => 'timecreated',
         'timemodified' => 'timemodified',
         'usermodified' => 'usermodified',
-        'metric' => 'metric',
         'configclass' => 'configclass',
         'tags' => 'tags',
     ];
@@ -423,7 +424,6 @@ final class registered_metric implements cacheable_object_interface, IteratorAgg
         foreach (self::CACHE_FIELDS as $field) {
             $data[$field] = match ($field) {
                 'tags' => array_map(fn (metric_tag $tag): array => $tag->prepare_to_cache(), $this->tags),
-                'metric' => get_class($this->metric), // Store just the class name.
                 default => $this->$field,
             };
         }
@@ -453,9 +453,15 @@ final class registered_metric implements cacheable_object_interface, IteratorAgg
         if (!empty($extra)) {
             debugging("Unexpected cache fields for registered_metric {$data['id']}:" . implode(', ', $extra), DEBUG_DEVELOPER);
         }
+        // Construct the instance using only the DB fields first.
         $instance = new self(...array_intersect_key($data, array_flip(self::FIELDS)));
-        $metric = new $data['metric'](); // Construct from the class name.
+        // Next, find the matching metric instance from the collection and set it on the new object.
+        $collection = di::get(metric_collection::class);
+        if (is_null($metric = $collection->get($instance->component, $instance->name))) {
+            throw new coding_exception("No metric collected for component '$instance->component' and name '$instance->name'");
+        }
         $instance->set_metric($metric);
+        // Finally, wake the associated tag instances and assign those to the new object as well.
         $instance->tags = array_map(fn (array $tag): metric_tag => metric_tag::wake_from_cache($tag), $data['tags']);
         return $instance;
     }

--- a/classes/registered_metric.php
+++ b/classes/registered_metric.php
@@ -390,6 +390,9 @@ final class registered_metric implements cacheable_object_interface, IteratorAgg
             }
         }
         metric_tag::set_for_metric($this, ...$formdata->tags);
+        if (metric_tag::normalize($formdata->tags) !== array_keys($this->tags)) {
+            $this->tags = metric_tag::get_for_metric_ids($this->id)[$this->id];
+        }
         if (empty($events)) {
             return;
         }

--- a/configure.php
+++ b/configure.php
@@ -29,7 +29,7 @@
  * {@noinspection PhpUnhandledExceptionInspection}
  */
 
-use core\exception\moodle_exception;
+use core\di;
 use tool_monitoring\metrics_manager;
 use tool_monitoring\output\configure;
 
@@ -47,11 +47,7 @@ admin_externalpage_setup('tool_monitoring_overview');
 $PAGE->set_secondary_active_tab('modules');
 $PAGE->set_url('/admin/tool/monitoring/configure.php', ['metric' => $qualifiedname]);
 
-$manager = new metrics_manager();
-$metric = $manager->sync(delete: true)->metrics[$qualifiedname] ?? null;
-if (is_null($metric)) {
-    throw new moodle_exception('invalidrecord', 'error', '', 'tool_monitoring_metrics');
-}
+$metric = di::get(metrics_manager::class)->sync(delete: true)[$qualifiedname]; // May throw a metric_not_found exception.
 $configure = new configure($metric);
 if ($configure->process_form()) {
     redirect(new moodle_url('/admin/tool/monitoring/'));

--- a/db/caches.php
+++ b/db/caches.php
@@ -15,9 +15,9 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Registration of metrics via the Hooks API.
+ * Cache definitions.
  *
- * @link https://moodledev.io/docs/apis/core/hooks#registering-of-hook-callbacks API Documentation
+ * @link https://moodledev.io/docs/apis/subsystems/muc#creating-a-definition Cache API documentation
  *
  * @package    tool_monitoring
  * @copyright  2025 MootDACH DevCamp
@@ -29,17 +29,22 @@
  * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use core\hook\di_configuration;
-use tool_monitoring\hook\metric_collection;
-use tool_monitoring\local\metrics;
+use tool_monitoring\metrics_manager;
 
 defined('MOODLE_INTERNAL') || die();
 
-$callbacks = [
-    ['hook' => di_configuration::class, 'callback' => [metric_collection::class, 'configure_dependency_injection']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\courses::class, 'collect']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\overdue_tasks::class, 'collect']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\quiz_attempts_in_progress::class, 'collect']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\user_accounts::class, 'collect']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\users_online::class, 'collect']],
+$definitions = [
+    'metrics' => [
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => true,
+        'simpledata' => true,
+        'datasource' => metrics_manager::class,
+        'staticacceleration' => true,
+    ],
+    'metric_tags' => [
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => true,
+        'simpledata' => true,
+        'staticacceleration' => true,
+    ],
 ];

--- a/db/caches.php
+++ b/db/caches.php
@@ -43,7 +43,6 @@ $definitions = [
     ],
     'metric_tags' => [
         'mode' => cache_store::MODE_APPLICATION,
-        'simplekeys' => true,
         'simpledata' => true,
         'staticacceleration' => true,
     ],

--- a/db/events.php
+++ b/db/events.php
@@ -15,9 +15,9 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Registration of metrics via the Hooks API.
+ * Description of event observers.
  *
- * @link https://moodledev.io/docs/apis/core/hooks#registering-of-hook-callbacks API Documentation
+ * @link https://docs.moodle.org/dev/Events_API#Event_observers Events API documentation
  *
  * @package    tool_monitoring
  * @copyright  2025 MootDACH DevCamp
@@ -29,17 +29,34 @@
  * @license    https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use core\hook\di_configuration;
-use tool_monitoring\hook\metric_collection;
-use tool_monitoring\local\metrics;
+use core\event\tag_added;
+use core\event\tag_created;
+use core\event\tag_deleted;
+use core\event\tag_removed;
+use core\event\tag_updated;
+use tool_monitoring\event\observer;
 
 defined('MOODLE_INTERNAL') || die();
 
-$callbacks = [
-    ['hook' => di_configuration::class, 'callback' => [metric_collection::class, 'configure_dependency_injection']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\courses::class, 'collect']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\overdue_tasks::class, 'collect']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\quiz_attempts_in_progress::class, 'collect']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\user_accounts::class, 'collect']],
-    ['hook' => metric_collection::class, 'callback' => [metrics\users_online::class, 'collect']],
+$observers = [
+    [
+        'eventname' => tag_added::class,
+        'callback' => [observer::class, 'tag_instance_added_or_removed'],
+    ],
+    [
+        'eventname' => tag_created::class,
+        'callback' => [observer::class, 'tag_created_or_deleted_or_updated'],
+    ],
+    [
+        'eventname' => tag_deleted::class,
+        'callback' => [observer::class, 'tag_created_or_deleted_or_updated'],
+    ],
+    [
+        'eventname' => tag_removed::class,
+        'callback' => [observer::class, 'tag_instance_added_or_removed'],
+    ],
+    [
+        'eventname' => tag_updated::class,
+        'callback' => [observer::class, 'tag_created_or_deleted_or_updated'],
+    ],
 ];

--- a/db/tag.php
+++ b/db/tag.php
@@ -31,13 +31,13 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-use tool_monitoring\registered_metric;
+use tool_monitoring\metric_tag;
 
 $tagareas = [
     [
-        'itemtype' => registered_metric::TABLE,
+        'itemtype' => metric_tag::ITEM_TYPE,
         'customurl' => '/admin/tool/monitoring/',
-        'collection' => 'monitoring',
+        'collection' => metric_tag::COLLECTION_NAME,
         'searchable' => false,
     ],
 ];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -29,15 +29,17 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-use tool_monitoring\registered_metric;
+use core\exception\moodle_exception;
+use tool_monitoring\metric_tag;
 
 /**
  * Upgrade code for the monitoring tool.
  *
  * @param int $oldversion
  * @return bool
- * @throws ddl_exception
- * @throws dml_exception
+ * @throws moodle_exception
+ *
+ * {@noinspection PhpUnused}
  */
 function xmldb_tool_monitoring_upgrade(int $oldversion): bool {
     global $DB;
@@ -48,16 +50,16 @@ function xmldb_tool_monitoring_upgrade(int $oldversion): bool {
         // The tag itemtype must match an existing DB table name. Older versions used "metrics",
         // but the actual records live in "tool_monitoring_metrics", so migrate both area and instances.
         $DB->set_field(
-            'tag_area',
-            'itemtype',
-            registered_metric::TABLE,
-            ['component' => 'tool_monitoring', 'itemtype' => 'metrics']
+            table: 'tag_area',
+            newfield: 'itemtype',
+            newvalue: metric_tag::ITEM_TYPE,
+            conditions: ['component' => 'tool_monitoring', 'itemtype' => 'metrics']
         );
         $DB->set_field(
-            'tag_instance',
-            'itemtype',
-            registered_metric::TABLE,
-            ['component' => 'tool_monitoring', 'itemtype' => 'metrics']
+            table: 'tag_instance',
+            newfield: 'itemtype',
+            newvalue: metric_tag::ITEM_TYPE,
+            conditions: ['component' => 'tool_monitoring', 'itemtype' => 'metrics']
         );
 
         $transaction->allow_commit();

--- a/exporter/prometheus/classes/exporter.php
+++ b/exporter/prometheus/classes/exporter.php
@@ -29,7 +29,12 @@
 
 namespace monitoringexporter_prometheus;
 
+use core\di;
+use core\exception\coding_exception;
+use dml_exception;
+use tool_monitoring\exceptions\tag_not_found;
 use tool_monitoring\metric_value;
+use tool_monitoring\metrics_manager;
 use tool_monitoring\registered_metric;
 
 /**
@@ -48,13 +53,22 @@ use tool_monitoring\registered_metric;
  */
 class exporter {
     /**
-     * Exports the provided metrics in the Prometheus text format.
+     * Exports enabled metrics in the Prometheus text format.
      *
-     * @param registered_metric[] $metrics Array of metric instances to export.
+     * @param string ...$tagnames Names of tags to filter the metrics by. Exports only metrics that carry all the specified tags.
+     *                            Names will be normalized before looking up the tags. Not passing any disables this filter.
      * @return string Prometheus text format.
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws tag_not_found At least one of the provided `$tagnames` does not match any existing metric tag.
      */
-    public static function export(array $metrics): string {
-        return implode("\n", array_map([self::class, 'export_metric'], $metrics));
+    public static function export(string ...$tagnames): string {
+        $manager = di::get(metrics_manager::class);
+        $lines = [];
+        foreach ($manager->filter(enabled: true, tagnames: $tagnames) as $metric) {
+            $lines[] = self::export_metric($metric);
+        }
+        return implode("\n", $lines);
     }
 
     /**

--- a/exporter/prometheus/classes/route/controller/prometheus.php
+++ b/exporter/prometheus/classes/route/controller/prometheus.php
@@ -40,7 +40,6 @@ use monitoringexporter_prometheus\exporter as prometheus_exporter;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use tool_monitoring\exceptions\tag_not_found;
-use tool_monitoring\metrics_manager;
 
 /**
  * Provides the route for Prometheus to pull the current metrics.
@@ -74,8 +73,6 @@ class prometheus {
      * @param Request $request Incoming, server-side HTTP request.
      * @param Response $response Outgoing, server-side response; the returned response object is derived from this.
      * @return Response Plain text response in the Prometheus format.
-     * @throws coding_exception
-     * @throws dml_exception
      *
      * {@noinspection PhpUnused}
      */
@@ -110,18 +107,18 @@ class prometheus {
         if ($expectedtoken && $params['token'] !== $expectedtoken) {
             return $response->withStatus(403);
         }
-        $manager = new metrics_manager();
         if ($params['tag']) {
-            $tags = explode(',', $params['tag']);
+            $tagnames = explode(',', $params['tag']);
         } else {
-            $tags = [];
+            $tagnames = [];
         }
         try {
-            $metrics = $manager->fetch(tagnames: $tags)->metrics;
+            $body = Utils::streamFor(prometheus_exporter::export(...$tagnames));
         } catch (tag_not_found) {
             return $response->withStatus(422);
+        } catch (coding_exception | dml_exception) {
+            return $response->withStatus(500);
         }
-        $body = Utils::streamFor(prometheus_exporter::export($metrics));
         return $response->withBody($body)->withHeader('Content-Type', 'text/plain; charset=utf-8');
     }
 }

--- a/exporter/prometheus/tests/behat/behat_monitoringexporter_prometheus.php
+++ b/exporter/prometheus/tests/behat/behat_monitoringexporter_prometheus.php
@@ -66,4 +66,5 @@ class behat_monitoringexporter_prometheus extends behat_base {
         }
         $this->getSession()->visit($this->locatePath($path));
     }
+    // TODO: Add a step to check the endpoint's response against a table of expected metrics quickly. Currently it is very slow.
 }

--- a/exporter/prometheus/tests/behat/tag.feature
+++ b/exporter/prometheus/tests/behat/tag.feature
@@ -68,7 +68,7 @@ Feature: Exporting tagged metrics
     And I should not see "tool_monitoring_quiz_attempts_in_progress"
     And I should not see "tool_monitoring_user_accounts"
     And I should not see "tool_monitoring_users_online"
-    # Order should matter and the parameter should be case-insensitive.
+    # Order should not matter and the parameter should be case-insensitive.
     When I call the Prometheus endpoint with the following query parameters:
       | tag | bAr,Foo |
     Then I should see "# HELP tool_monitoring_user_accounts"
@@ -86,3 +86,26 @@ Feature: Exporting tagged metrics
     And I should not see "tool_monitoring_user_accounts"
     And I should not see "tool_monitoring_users_online"
     And I should see "422"
+    # Now add a tag that was previously missing.
+    Given I am logged in as "manager1"
+    And I navigate to "Plugins > Admin tools > Monitoring > Overview" in site administration
+    And I click on "Configure" "link" in the "user_accounts" "table_row"
+    When I set the following fields to these values:
+      | Tags | Foo, Bar, Quux |
+    And I click on "Save changes" "button"
+    Then "Overview of Available Metrics" "heading" should be visible
+    When I call the Prometheus endpoint with the following query parameters:
+      | tag | foo,quux |
+    Then I should see "# HELP tool_monitoring_user_accounts"
+    And I should see "# TYPE tool_monitoring_user_accounts gauge"
+    # Remove tag instances.
+    Given I am logged in as "manager1"
+    And I navigate to "Plugins > Admin tools > Monitoring > Overview" in site administration
+    And I click on "Configure" "link" in the "user_accounts" "table_row"
+    When I set the following fields to these values:
+      | Tags | Bar |
+    And I click on "Save changes" "button"
+    Then "Overview of Available Metrics" "heading" should be visible
+    When I call the Prometheus endpoint with the following query parameters:
+      | tag | foo |
+    Then I should not see "tool_monitoring_user_accounts"

--- a/index.php
+++ b/index.php
@@ -29,6 +29,8 @@
  * {@noinspection PhpUnhandledExceptionInspection}
  */
 
+use core\di;
+use tool_monitoring\metric_tag;
 use tool_monitoring\metrics_manager;
 use tool_monitoring\output\overview;
 
@@ -44,21 +46,22 @@ require_capability('tool/monitoring:manage_metrics', context_system::instance())
 // Handle tags parameter for filtering of multiple tags.
 $taglist = optional_param('tag', '', PARAM_TAGLIST);
 $params = [];
-$manager = new metrics_manager();
-$manager->sync(delete: true);
 if ($taglist) {
-    $tags = explode(',', $taglist);
+    $tagnames = explode(',', $taglist);
     $params['tag'] = $taglist;
-    $manager->fetch(collect: false, enabled: null, tagnames: $tags);
 } else {
-    $tags = [];
+    $tagnames = [];
 }
 
 admin_externalpage_setup('tool_monitoring_overview');
 $PAGE->set_secondary_active_tab('modules');
 $PAGE->set_url('/admin/tool/monitoring/', $params);
 
-$overview = new overview(metrics: $manager->metrics, tags: $manager->tags);
+$manager = di::get(metrics_manager::class)->sync(delete: true);
+$overview = new overview(
+    metrics: $manager->filter(tagnames: $tagnames),
+    tags: metric_tag::get_all_with_names(...$tagnames),
+);
 echo $OUTPUT->header();
 echo $OUTPUT->render($overview);
 echo $OUTPUT->footer();

--- a/lang/en/tool_monitoring.php
+++ b/lang/en/tool_monitoring.php
@@ -35,6 +35,7 @@ $string['error:form_data_value_missing'] = 'Form data is missing a value for the
 $string['error:json_invalid'] = 'Invalid JSON encountered or the top-level type in that JSON is wrong.';
 $string['error:json_key_missing'] = 'JSON object is missing the "{$a->key}" key.';
 $string['error:metric_config_not_implemented'] = 'The "{$a->classname}" class does not implement the "metric_config" interface.';
+$string['error:metric_not_found'] = 'No metric with the qualified name "{$a->qualifiedname}" is registered.';
 $string['error:quiz_attempts_in_progress_config:input_invalid'] = 'Invalid input';
 $string['error:simple_metric_config_constructor_missing'] = 'The "{$a->classname}" class does not have a constructor.';
 $string['error:tag_not_found'] = 'No tag named "{$a->tagname}" exists in the "{$a->collectionname}" collection.';

--- a/tests/behat/behat_tool_monitoring.php
+++ b/tests/behat/behat_tool_monitoring.php
@@ -30,7 +30,7 @@
  */
 
 use Behat\Step\Given;
-use tool_monitoring\registered_metric;
+use tool_monitoring\metric_tag;
 
 require_once(__DIR__ . '/../../../../../lib/behat/behat_base.php');
 
@@ -67,7 +67,7 @@ class behat_tool_monitoring extends behat_base {
         };
         $area = $DB->get_record(
             table: 'tag_area',
-            conditions: ['itemtype' => registered_metric::TABLE, 'component' => 'tool_monitoring'],
+            conditions: ['itemtype' => metric_tag::ITEM_TYPE, 'component' => 'tool_monitoring'],
             strictness: MUST_EXIST,
         );
         core_tag_area::update($area, ['enabled' => $enabled]);

--- a/tests/behat/tag.feature
+++ b/tests/behat/tag.feature
@@ -27,7 +27,7 @@ Feature: Tagging metrics
       | 1       | disabled                   | should not           |
       | 1       | enabled                    | should               |
 
-  Scenario: Tags can be added to metrics and the overview can be filtered by tags
+  Scenario: Metric tags can be added/removed and the overview can be filtered by tags
     Given I am logged in as "manager1"
     And I navigate to "Plugins > Admin tools > Monitoring > Overview" in site administration
     # Add tags to one metric.

--- a/tests/exceptions/tool_monitoring_exception_test.php
+++ b/tests/exceptions/tool_monitoring_exception_test.php
@@ -52,6 +52,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 #[CoversClass(json_invalid::class)]
 #[CoversClass(json_key_missing::class)]
 #[CoversClass(metric_config_not_implemented::class)]
+#[CoversClass(metric_not_found::class)]
 #[CoversClass(simple_metric_config_constructor_missing::class)]
 #[CoversClass(tag_not_found::class)]
 #[CoversClass(tool_monitoring_exception::class)]
@@ -120,6 +121,13 @@ final class tool_monitoring_exception_test extends advanced_testcase {
                 'errorcode' => 'error:metric_config_not_implemented',
                 'module' => 'tool_monitoring',
                 'message' => 'The "baz" class does not implement the "metric_config" interface.',
+            ],
+            [
+                'exceptionclass' => metric_not_found::class,
+                'properties' => ['qualifiedname' => 'quux'],
+                'errorcode' => 'error:metric_not_found',
+                'module' => 'tool_monitoring',
+                'message' => 'No metric with the qualified name "quux" is registered.',
             ],
             [
                 'exceptionclass' => simple_metric_config_constructor_missing::class,

--- a/tests/hook/metric_collection_test.php
+++ b/tests/hook/metric_collection_test.php
@@ -33,7 +33,9 @@ namespace tool_monitoring\hook;
 
 use advanced_testcase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use tool_monitoring\local\testing\metric_settable_values;
+use tool_monitoring\local\metrics\courses;
+use tool_monitoring\local\metrics\quiz_attempts_in_progress;
+use tool_monitoring\local\metrics\user_accounts;
 
 /**
  * Unit tests for the {@see metric_collection} hook.
@@ -50,16 +52,25 @@ use tool_monitoring\local\testing\metric_settable_values;
 #[CoversClass(metric_collection::class)]
 final class metric_collection_test extends advanced_testcase {
     /**
-     * Tests the {@see metric_collection::add} method and the {@see IteratorAggregate} implementation.
+     * Tests adding and retrieving metrics.
+     *
+     * - The {@see metric_collection::add `add`} method.
+     * - The {@see metric_collection::get `get`} method.
+     * - The {@see IteratorAggregate} implementation.
      */
-    public function test_add_and_iterator(): void {
-        $metric1 = new metric_settable_values();
-        $metric2 = new metric_settable_values();
-        $metric3 = new metric_settable_values();
+    public function test_add_get_and_iterator(): void {
+        $metric0 = new courses();
+        $metric1 = new courses();
+        $metric2 = new quiz_attempts_in_progress();
+        $metric3 = new user_accounts();
         $collection = new metric_collection();
-        $collection->add($metric1);
+        $collection->add($metric0);
+        $collection->add($metric1); // Should replace `$metric0`.
         $collection->add($metric2);
         $collection->add($metric3);
+        self::assertSame($metric1, $collection->get('tool_monitoring', 'courses'));
+        self::assertSame($metric2, $collection->get('tool_monitoring', 'quiz_attempts_in_progress'));
+        self::assertSame($metric3, $collection->get('tool_monitoring', 'user_accounts'));
         $metrics = iterator_to_array($collection);
         self::assertSame([$metric1, $metric2, $metric3], $metrics);
     }

--- a/tests/metric_test.php
+++ b/tests/metric_test.php
@@ -36,6 +36,7 @@ use core\exception\coding_exception;
 use core\lang_string;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
 use tool_monitoring\hook\metric_collection;
 use tool_monitoring\local\metrics\overdue_tasks;
 use tool_monitoring\local\metrics\users_online;
@@ -55,6 +56,15 @@ use tool_monitoring\local\testing\metric_settable_values;
  */
 #[CoversClass(metric::class)]
 final class metric_test extends advanced_testcase {
+    public function test___construct(): void {
+        $cls = new ReflectionClass(metric::class);
+        $constructor = $cls->getConstructor();
+        self::assertNotNull($constructor);
+        self::assertTrue($constructor->isPublic());
+        self::assertTrue($constructor->isFinal());
+        self::assertSame([], $constructor->getParameters());
+    }
+
     public function test_collect(): void {
         $collection = new metric_collection();
         // The collection should not yet have the test metric.

--- a/tests/metric_test.php
+++ b/tests/metric_test.php
@@ -72,9 +72,9 @@ final class metric_test extends advanced_testcase {
         $metric = metric_settable_values::collect($collection);
         // Now the collection should have the test metric.
         self::assertSame([$metric], iterator_to_array($collection));
-        // Doing the same thing again should create a new instance and extend the collection.
+        // Doing the same thing again should create a new instance and replace the previous one in the collection.
         $metric2 = metric_settable_values::collect($collection);
-        self::assertSame([$metric, $metric2], iterator_to_array($collection));
+        self::assertSame([$metric2], iterator_to_array($collection));
     }
 
     /**

--- a/tests/metrics_manager_test.php
+++ b/tests/metrics_manager_test.php
@@ -32,12 +32,13 @@
 namespace tool_monitoring;
 
 use advanced_testcase;
-use context_system;
+use core\di;
 use core\exception\coding_exception;
-use core_tag_tag;
 use dml_exception;
+use JsonException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use tool_monitoring\exceptions\metric_not_found;
 use tool_monitoring\exceptions\tag_not_found;
 use tool_monitoring\hook\metric_collection;
 use tool_monitoring\local\metrics;
@@ -73,20 +74,12 @@ final class metrics_manager_test extends advanced_testcase {
     }
 
     public function test___construct(): void {
-        $manager = new metrics_manager();
-        self::assertSame([], iterator_to_array($manager->collection));
-        self::assertSame([], $manager->metrics);
-
+        // Test manual construction.
         $collection = new metric_collection();
         $manager = new metrics_manager($collection);
         self::assertSame($collection, $manager->collection);
-        self::assertSame([], $manager->metrics);
-    }
-
-    public function test_dispatch_collection(): void {
-        $collection = new metric_collection();
-        $manager = new metrics_manager($collection);
-        $manager->dispatch_hook();
+        // Check that DI dispatches the collection hook automatically and it subsequently contains our expected metrics.
+        $manager = di::get(metrics_manager::class);
         $expected = [
             metrics\courses::class,
             metrics\overdue_tasks::class,
@@ -102,29 +95,33 @@ final class metrics_manager_test extends advanced_testcase {
         }
         self::assertEmpty(array_diff($expected, $metricclasses));
         self::assertEmpty(array_diff($metricclasses, $expected));
+        // Check that the instances are the same when getting them repeatedly via the DI container.
+        self::assertSame($manager, di::get(metrics_manager::class));
     }
 
     /**
-     * Tests the {@see metrics_manager::fetch} method.
+     * Tests the {@see metrics_manager::getIterator} and {@see metrics_manager::filter} methods.
+     *
+     * Indirectly also tests the cache data source mechanism because iteration first attempts to load metrics from the cache.
      *
      * @param metric[] $collected Metric instances to add to the collection beforehand.
      * @param array<string, mixed>[] $registered Associative arrays of data to insert into the {@see registered_metric::TABLE}
      *                                           before calling the tested function.
      * @param array<string, array<string, mixed>> $expected Associative arrays of property name-value-pairs expected to be present
      *                                                      on the metric instances. Indexed by qualified name.
-     * @param bool|null $enabled Passed to the tested function.
-     * @param string|null $expectedwarning If passed a string, a warning is expected to be triggered containing that text.
+     * @param bool|null $enabled Passed to the {@see metrics_manager::filter} function.
+     * @param array $tagnames Passed to the {@see metrics_manager::filter} function.
      * @throws coding_exception
      * @throws dml_exception
      * @throws tag_not_found
      */
-    #[DataProvider('provider_test_fetch')]
-    public function test_fetch(
+    #[DataProvider('provider_test_filter')]
+    public function test_filter(
         array $collected,
         array $registered,
         array $expected,
         bool|null $enabled = null,
-        string|null $expectedwarning = null,
+        array $tagnames = [],
     ): void {
         global $DB;
         $this->resetAfterTest();
@@ -133,45 +130,41 @@ final class metrics_manager_test extends advanced_testcase {
         foreach ($collected as $metric) {
             $collection->add($metric);
         }
-        $manager = new metrics_manager($collection);
+        di::set(metric_collection::class, $collection);
+        $manager = di::get(metrics_manager::class);
         // Sanity check.
         self::assertSame(0, $DB->count_records(registered_metric::TABLE));
         // Add pre-existing metrics records.
+        $defaults = [
+            'component'    => 'tool_monitoring',
+            'timecreated'  => 123,
+            'timemodified' => 456,
+            'usermodified' => 1,
+        ];
         foreach ($registered as $toinsert) {
-            $DB->insert_record(registered_metric::TABLE, $toinsert);
+            $metricid = $DB->insert_record(registered_metric::TABLE, $toinsert + $defaults);
+            if (isset($toinsert['tags'])) {
+                metric_tag::set_for_metric($metricid, ...$toinsert['tags']);
+            }
         }
         $records = $DB->get_records(registered_metric::TABLE);
-        // Get ready to intercept warnings.
-        $lastwarning = null;
-        set_error_handler(
-            static function (int $errno, string $errstr) use (&$lastwarning): void {
-                $lastwarning = $errstr;
-            },
-        );
-        // Do the thing.
-        $manager->fetch(enabled: $enabled);
-        restore_error_handler();
-        if (!is_null($expectedwarning)) {
-            self::assertNotNull($lastwarning);
-            self::assertStringContainsString($expectedwarning, $lastwarning);
-        } else {
-            self::assertNull($lastwarning);
-        }
-        // The number of registered metrics should be as expected.
-        self::assertCount(count($expected), $manager->metrics);
+        // Consume the iterator.
+        $metrics = $manager->filter(enabled: $enabled, tagnames: $tagnames);
         // The records in the DB table should be unchanged.
         self::assertEquals($records, $DB->get_records(registered_metric::TABLE));
+        // The number of registered metrics should be as expected.
+        self::assertCount(count($expected), $metrics);
         // Check that the registered metrics are exactly as we expect them and there is a DB record for each of them.
         // To be extra sure, store already checked metric IDs.
         $checkedids = [];
         foreach ($expected as $qname => $properties) {
-            self::assertArrayHasKey($qname, $manager->metrics);
-            $metric = $manager->metrics[$qname];
+            self::assertArrayHasKey($qname, $metrics);
+            $metric = $metrics[$qname];
             self::assertNotNull($metric->id);
             self::assertNotContains($metric->id, $checkedids);
             self::assertArrayHasKey($metric->id, $records);
             $record = $records[$metric->id];
-            foreach ($properties as $name => $expectedvalue) {
+            foreach ($properties + $defaults as $name => $expectedvalue) {
                 self::assertEquals($expectedvalue, $record->$name);
                 self::assertEquals($expectedvalue, $metric->$name);
             }
@@ -180,11 +173,11 @@ final class metrics_manager_test extends advanced_testcase {
     }
 
     /**
-     * Provides test data for the {@see test_fetch} method.
+     * Provides test data for the {@see test_filter} method.
      *
      * @return array[] Arguments for the test method.
      */
-    public static function provider_test_fetch(): array {
+    public static function provider_test_filter(): array {
         return [
             'Collection of 3 different metrics; no pre-existing DB entries' => [
                 'collected' => [
@@ -203,32 +196,20 @@ final class metrics_manager_test extends advanced_testcase {
                 ],
                 'registered' => [
                     [
-                        'component'    => 'tool_monitoring',
-                        'name'         => 'foo',
-                        'enabled'      => false,
-                        'config'       => '{"a":1}',
-                        'timecreated'  => 10,
-                        'timemodified' => 20,
-                        'usermodified' => 1,
+                        'name'    => 'foo',
+                        'enabled' => false,
+                        'config'  => '{"a":1}',
                     ],
                     [
-                        'component'    => 'tool_monitoring',
-                        'name'         => 'bar',
-                        'enabled'      => true,
-                        'timecreated'  => 30,
-                        'timemodified' => 40,
-                        'usermodified' => 0,
+                        'name'    => 'bar',
+                        'enabled' => true,
                     ],
                 ],
                 'expected' => [
                     'tool_monitoring_foo' => [
-                        'component'    => 'tool_monitoring',
-                        'name'         => 'foo',
-                        'enabled'      => false,
-                        'config'       => '{"a":1}',
-                        'timecreated'  => 10,
-                        'timemodified' => 20,
-                        'usermodified' => 1,
+                        'name'    => 'foo',
+                        'enabled' => false,
+                        'config'  => '{"a":1}',
                     ],
                 ],
             ],
@@ -240,15 +221,10 @@ final class metrics_manager_test extends advanced_testcase {
                 ],
                 'registered' => [
                     [
-                        'component'    => 'tool_monitoring',
-                        'name'         => 'bar',
-                        'timecreated'  => 2,
-                        'timemodified' => 1,
-                        'usermodified' => 0,
+                        'name' => 'bar',
                     ],
                 ],
                 'expected' => [],
-                'expectedwarning' => "Collected more than one metric with the qualified name 'tool_monitoring_foo'",
             ],
             'Collection of 2 metrics, both registered, 1 disabled; getting enabled only' => [
                 'collected' => [
@@ -257,33 +233,18 @@ final class metrics_manager_test extends advanced_testcase {
                 ],
                 'registered' => [
                     [
-                        'component'    => 'tool_monitoring',
-                        'name'         => 'foo',
-                        'enabled'      => false,
-                        'config'       => '{"a":1}',
-                        'timecreated'  => 10,
-                        'timemodified' => 20,
-                        'usermodified' => 1,
+                        'name'    => 'foo',
+                        'enabled' => false,
                     ],
                     [
-                        'component'    => 'tool_monitoring',
-                        'name'         => 'bar',
-                        'enabled'      => true,
-                        'config'       => null,
-                        'timecreated'  => 30,
-                        'timemodified' => 40,
-                        'usermodified' => 0,
+                        'name'    => 'bar',
+                        'enabled' => true,
                     ],
                 ],
                 'expected' => [
                     'tool_monitoring_bar' => [
-                        'component'    => 'tool_monitoring',
-                        'name'         => 'bar',
-                        'enabled'      => true,
-                        'config'       => null,
-                        'timecreated'  => 30,
-                        'timemodified' => 40,
-                        'usermodified' => 0,
+                        'name'    => 'bar',
+                        'enabled' => true,
                     ],
                 ],
                 'enabled' => true,
@@ -295,38 +256,147 @@ final class metrics_manager_test extends advanced_testcase {
                 ],
                 'registered' => [
                     [
-                        'component'    => 'tool_monitoring',
-                        'name'         => 'foo',
-                        'enabled'      => false,
-                        'config'       => '{"a":1}',
-                        'timecreated'  => 10,
-                        'timemodified' => 20,
-                        'usermodified' => 1,
+                        'name'    => 'foo',
+                        'enabled' => false,
+                        'config'  => '{"a":1}',
                     ],
                     [
-                        'component'    => 'tool_monitoring',
-                        'name'         => 'bar',
-                        'enabled'      => true,
-                        'config'       => null,
-                        'timecreated'  => 30,
-                        'timemodified' => 40,
-                        'usermodified' => 0,
+                        'name'    => 'bar',
+                        'enabled' => true,
                     ],
                 ],
                 'expected' => [
                     'tool_monitoring_foo' => [
-                        'component'    => 'tool_monitoring',
-                        'name'         => 'foo',
-                        'enabled'      => false,
-                        'config'       => '{"a":1}',
-                        'timecreated'  => 10,
-                        'timemodified' => 20,
-                        'usermodified' => 1,
+                        'name'    => 'foo',
+                        'enabled' => false,
+                        'config'  => '{"a":1}',
                     ],
                 ],
                 'enabled' => false,
             ],
+            'Collection of 3 metrics, with 2 matching the single specified tag' => [
+                'collected' => [
+                    self::named_metric_factory(name: 'foo'),
+                    self::named_metric_factory(name: 'bar'),
+                    self::named_metric_factory(name: 'baz'),
+                ],
+                'registered' => [
+                    [
+                        'name' => 'foo',
+                        'tags' => ['spam', 'eggs'],
+                    ],
+                    [
+                        'name' => 'bar',
+                        'tags' => ['eggs', 'ham'],
+                    ],
+                    [
+                        'name' => 'baz',
+                        'tags' => ['spam', 'ham'],
+                    ],
+                ],
+                'expected' => [
+                    'tool_monitoring_foo' => [
+                        'name' => 'foo',
+                    ],
+                    'tool_monitoring_bar' => [
+                        'name' => 'bar',
+                    ],
+                ],
+                'enabled' => null,
+                'tagnames' => ['eggs'],
+            ],
+            'Collection of 3 metrics, only 1 matching all specified tags' => [
+                'collected' => [
+                    self::named_metric_factory(name: 'foo'),
+                    self::named_metric_factory(name: 'bar'),
+                    self::named_metric_factory(name: 'baz'),
+                ],
+                'registered' => [
+                    [
+                        'name' => 'foo',
+                        'tags' => ['spam', 'eggs'],
+                    ],
+                    [
+                        'name' => 'bar',
+                        'tags' => ['eggs', 'ham'],
+                    ],
+                    [
+                        'name' => 'baz',
+                        'tags' => ['spam', 'ham'],
+                    ],
+                ],
+                'expected' => [
+                    'tool_monitoring_foo' => [
+                        'name' => 'foo',
+                    ],
+                ],
+                'enabled' => null,
+                'tagnames' => ['eggs', 'spam'],
+            ],
         ];
+    }
+
+    /**
+     * Tests that the manager continues to produce the expected metrics after changes are made to tag instances.
+     *
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws tag_not_found
+     */
+    public function test_tag_instance_changes(): void {
+        global $DB;
+        $this->resetAfterTest();
+        // Add and register two metrics with some tag overlap.
+        $collection = new metric_collection();
+        $collection->add(self::named_metric_factory(name: 'foo'));
+        $collection->add(self::named_metric_factory(name: 'bar'));
+        di::set(metric_collection::class, $collection);
+        $manager = di::get(metrics_manager::class);
+        $defaults = [
+            'component'    => 'tool_monitoring',
+            'timecreated'  => 1,
+            'timemodified' => 1,
+            'usermodified' => 1,
+        ];
+        $metricidfoo = $DB->insert_record(registered_metric::TABLE, ['name' => 'foo', ...$defaults]);
+        $metricidbar = $DB->insert_record(registered_metric::TABLE, ['name' => 'bar', ...$defaults]);
+        metric_tag::set_for_metric($metricidfoo, 'spam', 'eggs');
+        metric_tag::set_for_metric($metricidbar, 'spam', 'beans');
+
+        // Sanity checks.
+        $metrictagsfoo = array_column($manager['tool_monitoring_foo']->tags, 'name');
+        self::assertSame(['spam', 'eggs'], $metrictagsfoo);
+        $metrics = $manager->filter(tagnames: ['spam', 'eggs']);
+        self::assertCount(1, $metrics);
+        self::assertSame($metricidfoo, reset($metrics)->id);
+
+        // Now we remove the tag instance; a new manager should no longer return the metric when filtering.
+        metric_tag::remove_item_tag(
+            component: 'tool_monitoring',
+            itemtype: metric_tag::ITEM_TYPE,
+            itemid: $metricidfoo,
+            tagname: 'spam',
+        );
+        di::reset_container();
+        di::set(metric_collection::class, $collection);
+        $manager = di::get(metrics_manager::class);
+        $metrics = $manager->filter(tagnames: ['spam', 'eggs']);
+        self::assertEmpty($metrics);
+        // The metric should no longer carry the tag when grabbed explicitly.
+        $metrictagsfoo = array_column($manager['tool_monitoring_foo']->tags, 'name');
+        self::assertSame(['eggs'], $metrictagsfoo);
+
+        // Now link the `eggs` tag to the `bar` metric as well; it should now be returned by a new manager.
+        metric_tag::set_for_metric($metricidbar, 'spam', 'eggs', 'beans');
+        di::reset_container();
+        di::set(metric_collection::class, $collection);
+        $manager = di::get(metrics_manager::class);
+        $metrics = $manager->filter(tagnames: ['spam', 'eggs']);
+        self::assertCount(1, $metrics);
+        self::assertSame($metricidbar, reset($metrics)->id);
+        // The metric should now carry the tag when grabbed explicitly.
+        $metrictagsbar = array_column($manager['tool_monitoring_bar']->tags, 'name');
+        self::assertSame(['spam', 'eggs', 'beans'], $metrictagsbar);
     }
 
     /**
@@ -339,9 +409,10 @@ final class metrics_manager_test extends advanced_testcase {
      *                                                      on the {@see registered_metric} instances as well as on the
      *                                                      corresponding raw database records. Indexed by qualified name.
      * @param bool $delete Passed to the tested method; `false` by default.
-     * @param string|null $expectedwarning If passed a string, a warning is expected to be triggered containing that text.
      * @throws coding_exception
      * @throws dml_exception
+     * @throws JsonException
+     * @throws tag_not_found
      */
     #[DataProvider('provider_test_sync')]
     public function test_sync(
@@ -349,7 +420,6 @@ final class metrics_manager_test extends advanced_testcase {
         array $registered,
         array $expected,
         bool $delete = false,
-        string|null $expectedwarning = null,
     ): void {
         global $DB;
         $this->resetAfterTest();
@@ -358,40 +428,27 @@ final class metrics_manager_test extends advanced_testcase {
         foreach ($collected as $metric) {
             $collection->add($metric);
         }
-        $manager = new metrics_manager($collection);
+        di::set(metric_collection::class, $collection);
+        $manager = di::get(metrics_manager::class);
         // Sanity check.
         self::assertSame(0, $DB->count_records(registered_metric::TABLE));
         // Add pre-existing metrics records.
         foreach ($registered as $toinsert) {
             $DB->insert_record(registered_metric::TABLE, $toinsert);
         }
-        // Prepare to intercept warnings.
-        $lastwarning = null;
-        set_error_handler(
-            static function (int $errno, string $errstr) use (&$lastwarning): void {
-                $lastwarning = $errstr;
-            },
-        );
         // Do the thing.
-        $manager->sync(collect: false, delete: $delete);
-        restore_error_handler();
-        if (!is_null($expectedwarning)) {
-            self::assertNotNull($lastwarning);
-            self::assertStringContainsString($expectedwarning, $lastwarning);
-        } else {
-            self::assertNull($lastwarning);
-        }
+        $metrics = $manager->sync(delete: $delete)->filter();
         // The number of registered metrics should be the same as the number of records in the DB table.
         $expectedcount = count($expected);
         $records = $DB->get_records(registered_metric::TABLE);
-        self::assertCount($expectedcount, $manager->metrics);
+        self::assertCount($expectedcount, $metrics);
         self::assertCount($expectedcount, $records);
         // Check that both the registered metrics and the raw DB records are exactly as we expect them.
         // To be extra sure, store already checked metric IDs.
         $checkedids = [];
         foreach ($expected as $qname => $properties) {
-            self::assertArrayHasKey($qname, $manager->metrics);
-            $metric = $manager->metrics[$qname];
+            $metric = $metrics[$qname] ?? null;
+            self::assertInstanceOf(registered_metric::class, $metric);
             self::assertNotNull($metric->id);
             self::assertNotContains($metric->id, $checkedids);
             self::assertArrayHasKey($metric->id, $records);
@@ -496,42 +553,15 @@ final class metrics_manager_test extends advanced_testcase {
                 ],
                 'delete' => true,
             ],
-            'Collection of 3 metrics with the same qualified name; 1 different pre-existing record; with deletion' => [
-                'collected' => [
-                    self::named_metric_factory(name: 'foo'),
-                    self::named_metric_factory(name: 'foo'),
-                    self::named_metric_factory(name: 'foo'),
-                ],
-                'registered' => [
-                    [
-                        'component'    => 'tool_monitoring',
-                        'name'         => 'bar',
-                        'enabled'      => true,
-                        'config'       => null,
-                        'timecreated'  => 30,
-                        'timemodified' => 40,
-                        'usermodified' => 0,
-                    ],
-                ],
-                'expected' => [
-                    'tool_monitoring_foo' => [
-                        'component'    => 'tool_monitoring',
-                        'name'         => 'foo',
-                        'enabled'      => false,
-                        'config'       => null,
-                        'usermodified' => $USER->id,
-                    ],
-                ],
-                'delete' => true,
-                'expectedwarning' => "Collected more than one metric with the qualified name 'tool_monitoring_foo'",
-            ],
         ];
     }
 
     /**
-     * Tests that deleting a metric also removes its tag associations.
+     * Tests that the {@see metrics_manager::sync} method removes tag associations when deleting a metric.
      *
+     * @throws coding_exception
      * @throws dml_exception
+     * @throws JsonException
      */
     public function test_sync_deletes_tag_instances_for_deleted_metrics(): void {
         global $DB;
@@ -551,28 +581,23 @@ final class metrics_manager_test extends advanced_testcase {
         self::assertNotNull($metricid);
 
         // Add tags alpha and beta to metric foo.
-        core_tag_tag::set_item_tags(
-            component: 'tool_monitoring',
-            itemtype: registered_metric::TABLE,
-            itemid: $metricid,
-            context: context_system::instance(),
-            tagnames: ['alpha', 'beta'],
-        );
+        metric_tag::set_for_metric($metricid, 'alpha', 'beta');
         self::assertSame(
             2,
             $DB->count_records('tag_instance', [
                 'component' => 'tool_monitoring',
-                'itemtype' => registered_metric::TABLE,
+                'itemtype' => metric_tag::ITEM_TYPE,
                 'itemid' => $metricid,
             ]),
         );
 
-        // Delete metric foo.
-        $deletemanager = new metrics_manager(new metric_collection());
-        $deletemanager->sync(collect: false, delete: true);
+        di::set(metric_collection::class, new metric_collection());
+        $manager = di::get(metrics_manager::class);
+        // This should delete the `foo` metric.
+        $manager->sync(delete: true);
         self::assertFalse($DB->record_exists(registered_metric::TABLE, ['id' => $metricid]));
 
-        // Assert that tags are gone, too.
+        // Ensure that tags are gone, too.
         self::assertSame(
             0,
             $DB->count_records('tag_instance', [
@@ -581,6 +606,52 @@ final class metrics_manager_test extends advanced_testcase {
                 'itemid' => $metricid,
             ]),
         );
-        self::assertSame([], core_tag_tag::get_item_tags_array('tool_monitoring', registered_metric::TABLE, $metricid));
+        self::assertSame([$metricid => []], metric_tag::get_for_metric_ids($metricid));
+    }
+
+    /**
+     * Tests {@see metrics_manager::offsetExists}, {@see metrics_manager::offsetGet}, and {@see metrics_manager::offsetUnset}.
+     *
+     * Indirectly also tests the cache data source mechanism because getter first attempts to load a metric from the cache.
+     *
+     * @throws dml_exception
+     */
+    public function test_array_access(): void {
+        global $DB;
+        $this->resetAfterTest();
+        $collection = new metric_collection();
+        $collection->add(self::named_metric_factory(name: 'foo'));
+        di::set(metric_collection::class, $collection);
+        $manager = di::get(metrics_manager::class);
+        $toinsert = [
+            'component'    => 'tool_monitoring',
+            'name'         => 'foo',
+            'enabled'      => false,
+            'timecreated'  => 10,
+            'timemodified' => 20,
+            'usermodified' => 1,
+        ];
+        $DB->insert_record(registered_metric::TABLE, $toinsert);
+        $qname = 'tool_monitoring_foo';
+        self::assertTrue(isset($manager[$qname]));
+        $metric = $manager[$qname];
+        self::assertInstanceOf(registered_metric::class, $metric);
+        self::assertSame($qname, $metric->qualifiedname);
+        // Ensure we cannot unset a metric.
+        $this->expectException(coding_exception::class);
+        unset($manager[$qname]);
+    }
+
+    public function test_array_metric_not_found(): void {
+        $manager = di::get(metrics_manager::class);
+        self::assertFalse(isset($manager['foo']));
+        $this->expectException(metric_not_found::class);
+        $manager['foo'];
+    }
+
+    public function test_array_set_error(): void {
+        $manager = di::get(metrics_manager::class);
+        $this->expectException(coding_exception::class);
+        $manager['foo'] = self::named_metric_factory(name: 'foo');
     }
 }

--- a/tests/registered_metric_test.php
+++ b/tests/registered_metric_test.php
@@ -39,6 +39,8 @@ use dml_exception;
 use JsonException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use tool_monitoring\local\metrics;
+use tool_monitoring\local\testing\custom_metric_config;
 use tool_monitoring\local\testing\metric_settable_values;
 use tool_monitoring\local\testing\metric_with_custom_config;
 
@@ -57,68 +59,128 @@ use tool_monitoring\local\testing\metric_with_custom_config;
 #[CoversClass(registered_metric::class)]
 final class registered_metric_test extends advanced_testcase {
     /**
-     * Tests the {@see registered_metric::from_metric} method.
+     * Tests the {@see registered_metric::get_for_metrics} method.
      *
-     * @param metric $metric Metric instance to pass to the `from_metric` method.
-     * @param array $arguments Additional arguments to unpack into to the `from_metric` method.
-     * @param array|string $expected Expected properties of the returned object or exception class name.
+     * @param array<array<string, string>> $indb DB records to insert before calling the method.
+     * @param array $metrics Metric instances to pass to the  method.
+     * @param array<string, array<string, string>> $expected Arrays of expected instance properties of the returned objects indexed
+     *                                                       by qualified name.
+     * @throws coding_exception
+     * @throws dml_exception
+     * @throws JsonException
      */
-    #[DataProvider('provider_test_from_metric')]
-    public function test_from_metric(metric $metric, array $arguments, array|string $expected): void {
-        if (is_string($expected)) {
-            $this->expectException($expected);
-            registered_metric::from_metric($metric, ...$arguments);
-            return;
-        }
-        $instance = registered_metric::from_metric($metric, ...$arguments);
-        foreach ($expected as $name => $value) {
-            self::assertEquals($value, $instance->$name);
+    #[DataProvider('provider_test_get_for_metrics')]
+    public function test_get_for_metrics(array $indb, array $metrics, array $expected): void {
+        global $DB;
+        $this->resetAfterTest();
+        $DB->insert_records(registered_metric::TABLE, $indb);
+        $instances = registered_metric::get_for_metrics(...$metrics);
+        self::assertCount(count($expected), $instances);
+        foreach ($expected as $qname => $properties) {
+            $instance = $instances[$qname] ?? null;
+            self::assertInstanceOf(registered_metric::class, $instance);
+            foreach ($properties as $name => $value) {
+                self::assertEquals($value, $instance->$name, "Unexpected $name on $qname instance");
+            }
         }
     }
 
     /**
-     * Provides test data for the {@see test_from_metric} method.
+     * Provides test data for the {@see test_get_for_metrics} method.
      *
      * @return array[] Arguments for the test method.
      */
-    public static function provider_test_from_metric(): array {
-        $metric = new metric_settable_values();
+    public static function provider_test_get_for_metrics(): array {
+        $defaults = [
+            'component'    => 'tool_monitoring',
+            'enabled'      => false,
+            'config'       => null,
+            'timecreated'  => null,
+            'timemodified' => null,
+            'usermodified' => null,
+        ];
+        $metricmissing = new metric_settable_values();
+        $metricquizattempts = new metrics\quiz_attempts_in_progress();
+        $metricuseraccounts = new metrics\user_accounts();
         return [
-            'No additional arguments' => [
-                'metric'    => $metric,
-                'arguments' => [],
-                'expected'  => [
-                    'id'           => null,
-                    'component'    => 'tool_monitoring',
-                    'name'         => 'metric_settable_values',
-                    'enabled'      => false,
-                    'config'       => null,
-                    'timecreated'  => null,
-                    'timemodified' => null,
-                    'usermodified' => null,
+            'No metrics provided' => [
+                'indb' => [
+                    [
+                        'component'    => 'tool_monitoring',
+                        'name'         => 'foo',
+                        'enabled'      => false,
+                        'timecreated'  => 1,
+                        'timemodified' => 1,
+                        'usermodified' => 1,
+                    ],
+                ],
+                'metrics' => [],
+                'expected' => [],
+            ],
+            'No records in the DB' => [
+                'indb' => [],
+                'metrics' => [
+                    $metricmissing,
+                    $metricquizattempts,
+                    $metricuseraccounts,
+                ],
+                'expected' => [
+                    'tool_monitoring_metric_settable_values' => [
+                        'name' => 'metric_settable_values',
+                    ] + $defaults,
+                    'tool_monitoring_quiz_attempts_in_progress' => [
+                        'name'   => 'quiz_attempts_in_progress',
+                        'config' => '{"maxidleseconds":1200,"maxdeadlineseconds":10800}',
+                    ] + $defaults,
+                    'tool_monitoring_user_accounts' => [
+                        'name' => 'user_accounts',
+                    ] + $defaults,
                 ],
             ],
-            'All arguments override values from metric' => [
-                'metric'    => $metric,
-                'arguments' => [
-                    'id'           => 9000,
-                    'component'    => 'foo',
-                    'name'         => 'bar',
-                    'enabled'      => true,
-                    'config'       => '{"a":"b"}',
-                    'timecreated'  => 123,
-                    'timemodified' => 456,
-                    'usermodified' => 789,
+            'Two records in the DB' => [
+                'indb' => [
+                    [
+                        'component'    => 'tool_monitoring',
+                        'name'         => 'quiz_attempts_in_progress',
+                        'enabled'      => true,
+                        'config'       => '{"maxidleseconds":1200,"maxdeadlineseconds":10800}',
+                        'timecreated'  => 123,
+                        'timemodified' => 456,
+                        'usermodified' => 1,
+                    ],
+                    [
+                        'component'    => 'tool_monitoring',
+                        'name'         => 'user_accounts',
+                        'enabled'      => false,
+                        'config'       => null,
+                        'timecreated'  => 1,
+                        'timemodified' => 1,
+                        'usermodified' => 1,
+                    ],
                 ],
-                'expected'  => [
-                    'id'           => 9000,
-                    'component'    => 'foo',
-                    'name'         => 'bar',
-                    'enabled'      => true,
-                    'config'       => '{"a":"b"}',
-                    'timecreated'  => 123,
-                    'timemodified' => 456,
-                    'usermodified' => 789,
+                'metrics' => [
+                    $metricmissing,
+                    $metricquizattempts,
+                    $metricuseraccounts,
+                ],
+                'expected' => [
+                    'tool_monitoring_metric_settable_values' => [
+                        'name' => 'metric_settable_values',
+                    ] + $defaults,
+                    'tool_monitoring_quiz_attempts_in_progress' => [
+                        'name'         => 'quiz_attempts_in_progress',
+                        'enabled'      => true,
+                        'config'       => '{"maxidleseconds":1200,"maxdeadlineseconds":10800}',
+                        'timecreated'  => 123,
+                        'timemodified' => 456,
+                        'usermodified' => 1,
+                    ] + $defaults,
+                    'tool_monitoring_user_accounts' => [
+                        'name'         => 'user_accounts',
+                        'timecreated'  => 1,
+                        'timemodified' => 1,
+                        'usermodified' => 1,
+                    ] + $defaults,
                 ],
             ],
         ];
@@ -128,6 +190,7 @@ final class registered_metric_test extends advanced_testcase {
      * Tests the {@see IteratorAggregate} implementation of the {@see registered_metric} class.
      *
      * @param iterable<metric_value>|metric_value $testvalues Metric values to be produced by the test metric.
+     * @throws JsonException
      */
     #[DataProvider('provider_test_iterator')]
     public function test_iterator(iterable|metric_value $testvalues): void {
@@ -204,11 +267,21 @@ final class registered_metric_test extends advanced_testcase {
         ];
     }
 
+    /**
+     * Tests the {@see registered_metric::__get} method.
+     *
+     * @throws coding_exception
+     * @throws JsonException
+     */
     public function test___get(): void {
         $instance = registered_metric::from_metric(new metric_settable_values());
         self::assertSame(registered_metric::get_qualified_name($instance->component, $instance->name), $instance->qualifiedname);
         self::assertEquals(metric_settable_values::get_description(), $instance->description);
         self::assertSame(metric_settable_values::get_type(), $instance->type);
+        self::assertSame([], $instance->tags);
+        self::assertTrue(isset($instance->tags));
+        $instance = registered_metric::from_metric(new metric_with_custom_config());
+        self::assertSame(custom_metric_config::class, $instance->configclass);
     }
 
     /**
@@ -219,12 +292,14 @@ final class registered_metric_test extends advanced_testcase {
      * @param class-string<base_event>[] $events Names of event classes expected to be triggered in the given order.
      * @throws dml_exception
      * @throws coding_exception
+     * @throws JsonException
      */
     #[DataProvider('provider_test_persist_enabled_state')]
     public function test_persist_enabled_state(bool $from, bool $to, array $events): void {
         global $DB, $USER;
         $this->resetAfterTest();
-        $metric = registered_metric::from_metric(new metric_settable_values(), enabled: $from);
+        $metric = registered_metric::from_metric(new metric_settable_values());
+        $metric->enabled = $from;
         // Set modification time in the past and arbitrary user.
         $generator = $this->getDataGenerator();
         $creationtime = time() - 1000;
@@ -233,7 +308,7 @@ final class registered_metric_test extends advanced_testcase {
         $metric->timemodified = $creationtime;
         $metric->usermodified = $creationuser;
         // Insert record manually.
-        $metric->id = $DB->insert_record(registered_metric::TABLE, (array) $metric);
+        $metric->id = $DB->insert_record(registered_metric::TABLE, $metric->to_db());
         // Intercept the event here.
         $eventsink = $this->redirectEvents();
         $metric->persist_enabled_state($to);
@@ -348,14 +423,16 @@ final class registered_metric_test extends advanced_testcase {
         $metric->update_with_form_data((object) $formdata);
         $eventsink->close();
         $record = $DB->get_record(registered_metric::TABLE, ['id' => $metric->id]);
+        if (empty($events)) {
+            self::assertEquals($creationtime, $record->timemodified, "DB record timemodified unexpectedly changed");
+        } else {
+            // Time modified should have been updated.
+            self::assertGreaterThan($creationtime, $record->timemodified);
+        }
         // Check the expected values.
         foreach ($expected as $name => $value) {
-            self::assertEquals($value, $record->$name);
-            self::assertEquals($value, $metric->$name);
-        }
-        if (!empty($events)) {
-            // Time modified should have been updated as well.
-            self::assertGreaterThan($creationtime, $record->timemodified);
+            self::assertEquals($value, $record->$name, "Unexpected $name on DB record");
+            self::assertEquals($value, $metric->$name, "Unexpected $name on instance");
         }
         // Check that the events were triggered as expected.
         $actualevents = array_map(fn (base_event $event): string => $event::class, $eventsink->get_events());
@@ -366,13 +443,22 @@ final class registered_metric_test extends advanced_testcase {
      * Provides test data for the {@see test_update_with_form_data} method.
      *
      * @return array[] Arguments for the test method.
+     * @throws JsonException
      */
     public static function provider_test_update_with_form_data(): array {
-        $metric = new metric_settable_values();
-        $metricwithconfig = new metric_with_custom_config();
+        $metricenabled = registered_metric::from_metric(new metric_settable_values());
+        $metricenabled->enabled = true;
+        $metricdisabledwithconfig = registered_metric::from_metric(new metric_with_custom_config());
+        $metricdisabledwithconfig->config = '{"foo":"baz","spam":0}';
+        $metricenabledwithconfig = registered_metric::from_metric(new metric_with_custom_config());
+        $metricenabledwithconfig->enabled = true;
+        $metricenabledwithconfig->config = '{"foo":"baz","spam":0}';
+        $metricenabledwithoutconfig = registered_metric::from_metric(new metric_with_custom_config());
+        $metricenabledwithoutconfig->enabled = true;
+        $metricenabledwithoutconfig->config = '{}';
         return [
             'Enabled basic metric, nothing changed' => [
-                'metric'   => registered_metric::from_metric($metric, enabled: true),
+                'metric'   => $metricenabled,
                 'formdata' => [
                     'enabled' => true,
                     'tags' => [],
@@ -384,7 +470,7 @@ final class registered_metric_test extends advanced_testcase {
                 'events'   => [],
             ],
             'Enabled basic metric, being disabled, arbitrary form data present' => [
-                'metric'   => registered_metric::from_metric($metric, enabled: true),
+                'metric'   => $metricenabled,
                 'formdata' => [
                     'enabled' => false,
                     'tags' => [],
@@ -400,7 +486,7 @@ final class registered_metric_test extends advanced_testcase {
                 ],
             ],
             'Enabled configurable metric, nothing changed' => [
-                'metric'   => registered_metric::from_metric($metricwithconfig, enabled: true, config: '{"foo":"baz","spam":0}'),
+                'metric'   => $metricenabledwithconfig,
                 'formdata' => [
                     'enabled' => true,
                     'tags' => [],
@@ -414,7 +500,7 @@ final class registered_metric_test extends advanced_testcase {
                 'events'   => [],
             ],
             'Enabled configurable metric, having config updated' => [
-                'metric'   => registered_metric::from_metric($metricwithconfig, enabled: true, config: '{}'),
+                'metric'   => $metricenabledwithoutconfig,
                 'formdata' => [
                     'enabled' => true,
                     'tags' => [],
@@ -429,7 +515,7 @@ final class registered_metric_test extends advanced_testcase {
                 ],
             ],
             'Enabled configurable metric, being disabled' => [
-                'metric'   => registered_metric::from_metric($metricwithconfig, enabled: true, config: '{"foo":"baz","spam":0}'),
+                'metric'   => $metricenabledwithconfig,
                 'formdata' => [
                     'enabled' => false,
                     'tags' => [],
@@ -445,7 +531,7 @@ final class registered_metric_test extends advanced_testcase {
                 ],
             ],
             'Disabled configurable metric, being enabled' => [
-                'metric'   => registered_metric::from_metric($metricwithconfig, enabled: false, config: '{"foo":"baz","spam":0}'),
+                'metric'   => $metricenabledwithconfig,
                 'formdata' => [
                     'enabled' => true,
                     'tags' => [],
@@ -461,7 +547,7 @@ final class registered_metric_test extends advanced_testcase {
                 ],
             ],
             'Disabled configurable metric, being enabled and having config updated' => [
-                'metric'   => registered_metric::from_metric($metricwithconfig, enabled: false, config: '{"foo":"baz","spam":0}'),
+                'metric'   => $metricdisabledwithconfig,
                 'formdata' => [
                     'enabled' => true,
                     'tags' => [],

--- a/tests/registered_metric_test.php
+++ b/tests/registered_metric_test.php
@@ -34,6 +34,8 @@ namespace tool_monitoring;
 use advanced_testcase;
 use ArrayIterator;
 use core\event\base as base_event;
+use core\event\tag_added;
+use core\event\tag_created;
 use core\exception\coding_exception;
 use dml_exception;
 use JsonException;
@@ -429,6 +431,13 @@ final class registered_metric_test extends advanced_testcase {
             // Time modified should have been updated.
             self::assertGreaterThan($creationtime, $record->timemodified);
         }
+        // Check that tags are consistent and as expected.
+        if (isset($expected['tags'])) {
+            self::assertSame($expected['tags'], array_keys($metric->tags));
+            $tags = metric_tag::get_for_metric_ids($metric->id)[$metric->id];
+            self::assertSame($expected['tags'], array_keys($tags));
+            unset($expected['tags']);
+        }
         // Check the expected values.
         foreach ($expected as $name => $value) {
             self::assertEquals($value, $record->$name, "Unexpected $name on DB record");
@@ -560,6 +569,25 @@ final class registered_metric_test extends advanced_testcase {
                 ],
                 'events'   => [
                     event\metric_enabled::class,
+                    event\metric_config_updated::class,
+                ],
+            ],
+            'Changing tags and updating config at the same time' => [
+                'metric'   => $metricenabledwithconfig,
+                'formdata' => [
+                    'enabled' => true,
+                    'tags' => ['beans'],
+                    'foo'     => 'bar',
+                    'spam'    => 1,
+                ],
+                'expected' => [
+                    'config'  => '{"foo":"bar","spam":1}',
+                    'enabled' => true,
+                    'tags'    => ['beans'],
+                ],
+                'events'   => [
+                    tag_created::class,
+                    tag_added::class,
                     event\metric_config_updated::class,
                 ],
             ],

--- a/version.php
+++ b/version.php
@@ -32,7 +32,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'tool_monitoring';
-$plugin->release = '0.2.2';
-$plugin->version = 2026041000;
+$plugin->release = '0.3.0';
+$plugin->version = 2026050700;
 $plugin->requires = 2025041400; // Moodle 5.0.
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
As I mentioned previously, I wanted to implement **caching** for our registered metrics meta-data as well as the associated tags to speed up the endpoint as much as possible. This may or may not be overkill in practice, but it was a fun exercise and helped me understand the [MUC](https://moodledev.io/docs/apis/subsystems/muc) much better.

Here I introduce a couple of changes, mostly to the `metrics_manager`, to make this work. These changes incidentally also made the manager's interface a bit nicer in my opinion. But I am curious what you think.

## TL;DR

**Get the manager**

```php
$manager = di::get(metrics_manager::class);
```

**Chain with `sync`**

```php
$manager = di::get(metrics_manager::class)->sync(delete: true); // Populates the cache with entries for all registered metrics.
```

**Get a specific registered metric by qualified name**

```php
$metric = di::get(metrics_manager::class)->sync(delete: true)[$qualifiedname]; // May throw a metric_not_found exception.
```

**Get all enabled metrics that carry the `foo` tag**

```php
$manager = di::get(metrics_manager::class);
$metrics = $manager->filter(enabled: true, tagnames: ['foo']); // Populates the cache with entries for all collected metrics.
```

**Get all collected _and_ registered metrics**

```php
$manager = di::get(metrics_manager::class);
$metrics = $manager->filter(); // Populates the cache with entries for all collected metrics.
```

## Changes

### Dependency injection

The `metric_collection` hook now defines its own dependency injection config to get dispatched automatically, when [Moodle's DI container](https://moodledev.io/docs/apis/core/di) injects it somewhere. This allows the `metrics_manager` to be retrieved via DI as well and there is no longer a need to actively "dispatch the hook" from the outside. Since the DI container is automatically reset in Moodle's PHPUnit setup, testing also becomes much clearer. Thus the `dispatch_hook` method is gone from the manager; as is the optional `$collect` parameter in its `sync` method.

The canonical way to get a metrics manager is now the **same as with Moodle's hook manager**:

```php
use core\di;
use tool_monitoring\metrics_manager;

$manager = di::get(metrics_manager::class);
```

All metrics that hook into our `metrics_collection` event, are guaranteed to be collected and stored in the manager at this point. And since the DI container shares the reference to its dependencies for the lifetime of the request, subsequent retrievals of the manager will not trigger collection again.

In tests, to substitute a specific collection, we can now just do this:

```php
$collection = new metric_collection();
// Add metrics to the collection...
di::set(metric_collection::class, $collection);
$manager = di::get(metrics_manager::class);
```

As long as `resetAfterTest` is called in the test method, this has no effect on subsequent tests.

### Array-like manager

The manager allows subscript access to individual `registered_metric` instances by qualified name, like an associative array. It implements `ArrayAccess`. (It only allows reading, not removing/modifying keys.)

### Metrics cache and filtering

Collected and registered metrics can be retrieved via the `filter` method.
Calling it without arguments will return all of them.

```php
$manager = di::get(metrics_manager::class);
// Only get enabled metrics that carry the 'foo' tag:
foreach ($manager->filter(enabled: true, tagnames: ['foo']) as $qname => $metric) {
    // Now `$qname` is a string and `$metric` is a `registered_metric` object.
}
```

It always tries to get them from the cache first. With [static acceleration](https://moodledev.io/docs/apis/subsystems/muc#cache-modifiers) configured, this is almost as fast as storing them on the manager itself (for the lifetime of a request).

Since the manager implements the [`core_cache\data_source_interface`](https://moodledev.io/docs/5.1/apis/subsystems/muc#specifying-a-data-source), metrics not yet cached are fetched from the DB automatically and loaded into the cache.

The manager also does **explicit null-caching**, so if a qualified name requested from it did not match a collected metric _or_ that metric was not registered (yet), that fact is cached and subsequent requests no longer touch the DB.

Calling the `sync` method of course will register any newly picked up metrics and now also re-builds the cache.

### Cacheable `registered_metric`

To make this all convenient, the `registered_metric` implements the `cacheable_object_interface` _and_ it stores its tags in a separate property.

### `metric_tag` subclass

This exists mostly for convenience and extends the `core_tag_tag` class. It also implements the `cacheable_object_interface`.

### `metrics_cache` helper class

This is just a convenient and type safe wrapper around the cache store functions.

### Tag change events

To properly invalidate caches, event observers are registered for tag changes.

---

I would really appreciate your feedback on this one. I know it is a lot to go through, but I promise this is the last major feature/change I want before the v1.0 release.